### PR TITLE
Update PHP configuration to use ssmtp for sending emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ execute it by : `php /path/2/script`
 
 ## autodiscovery LDAP bind credentials
 
-You can add the environment variable LAMP_LDAP_DOMAIN to the ~/.config/state/environment file. Set it with the domain name you want to bind.
+You can add the environment variable `LAMP_LDAP_DOMAIN` to the `~/.config/state/environment` file. Set it with the domain name you want to bind.
 After that, restart the lamp systemd service. The complete bind credentials should be available as environment variables in the discovery.env file.
 These credentials should also be mounted as environment variables in the lamp-app container.
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,26 @@ You can add the environment variable `LAMP_LDAP_DOMAIN` to the `~/.config/state/
 After that, restart the lamp systemd service. The complete bind credentials should be available as environment variables in the discovery.env file.
 These credentials should also be mounted as environment variables in the lamp-app container.
 
+to modify:
+
+```
+runagent -m lamp1
+vi environment
+```
+
+add the domain you want to retrieve the bind credentials: `LAMP_LDAP_DOMAIN=rocky9-pve3.org`
+
+```
+systemctl restart --user lamp
+```
+
+check if everything is correctly written
+
+```
+cat discovery.env
+podman exec -ti lamp-app env
+```
+
 ## Debug
 
 some CLI are needed to debug

--- a/README.md
+++ b/README.md
@@ -129,6 +129,34 @@ See also the `systemd/user/lamp.service` file.
 This setting discovery is just an example to understand how the module is
 expected to work: it can be rewritten or discarded completely.
 
+
+We use ssmtp to handle sending emails from our server. The php.ini configuration is set to use the ssmtp -t command, allowing PHP to send emails seamlessly via ssmtp.
+For other programming languages, ensure that they are configured to use the ssmtp command similarly, typically by setting their mail sending command or path to `ssmtp -t`,
+just like in PHP. This way, all emails sent by different applications or scripts will be routed through ssmtp.
+
+
+
+you can try by the command line to send an email with a php script
+
+```
+<?php
+$to = 'recipient@example.com';
+$subject = 'Test Email';
+$message = 'This is a test email sent from PHP using ssmtp.';
+$headers = 'From: your-email@example.com' . "\r\n" .
+           'Reply-To: your-email@example.com' . "\r\n" .
+           'X-Mailer: PHP/' . phpversion();
+
+if(mail($to, $subject, $message, $headers)) {
+    echo 'Email sent successfully!';
+} else {
+    echo 'Failed to send email.';
+}
+?>
+```
+
+execute it by : `php /path/2/script`
+
 ## Debug
 
 some CLI are needed to debug

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ We use ssmtp to handle sending emails from our server. The php.ini configuration
 For other programming languages, ensure that they are configured to use the ssmtp command similarly, typically by setting their mail sending command or path to `ssmtp -t`,
 just like in PHP. This way, all emails sent by different applications or scripts will be routed through ssmtp.
 
-
+php settings example: `sendmail_path = /usr/sbin/ssmtp -t`
 
 you can try by the command line to send an email with a php script
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ You can also access phpMyAdmin by navigating to:
 
 The username is admin, and the password is the one you set in the user interface.
 
+### Wordpress installation example
+
+go to the container once you have saved the FQDN where the container is running, in you your browser go to  `https://FQDN` or `https://FQDN/phpmyadmin/`, a page must be displayed with software version and another with phpmyadmin
+
+- go into the container
+`runagent -m lamp1 podman exec -ti lamp-app bash`
+- go to the web folder
+`cd /app`
+- download wordpress
+`wget https://fr.wordpress.org/latest-fr_FR.zip`
+- unzip the archive
+`unzip latest-fr_FR.zip`
+- move web files to the root of the web folder
+`mv wordpress/* .`
+`mv wordpress/.* .`
+- go to the `https://FQDN` and finish the installation with the webfolder, you will need the credentials of a mysql user and its associated database name (either created the first time in the user interface or fwith phpmyadmin)
+
 ## Install
 
 Instantiate the module with:
@@ -130,7 +147,7 @@ This setting discovery is just an example to understand how the module is
 expected to work: it can be rewritten or discarded completely.
 
 
-We use ssmtp to handle sending emails from our server. The php.ini configuration is set to use the ssmtp -t command, allowing PHP to send emails seamlessly via ssmtp.
+We use ssmtp to handle sending emails from our server. The php.ini configuration is set to use the `ssmtp -t` command, allowing PHP to send emails seamlessly via ssmtp.
 For other programming languages, ensure that they are configured to use the ssmtp command similarly, typically by setting their mail sending command or path to `ssmtp -t`,
 just like in PHP. This way, all emails sent by different applications or scripts will be routed through ssmtp.
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Launch `configure-module`, by setting the following parameters:
 - `mysql_admin_pass`: password of the mysql admin user of all databases
 - `mysql_user_db`: database of the mysql user
 - `mysql_user_name`: name of the mysql user
--  `mysql_user_pass`: password of the mysql user
--  `php_upload_max_filesize`: maximum file size and maximum post size in MB
+- `mysql_user_pass`: password of the mysql user
+- `php_upload_max_filesize`: maximum file size and maximum post size in MB
 
 
 Example:
@@ -157,6 +157,12 @@ if(mail($to, $subject, $message, $headers)) {
 
 execute it by : `php /path/2/script`
 
+## autodiscovery LDAP bind credentials
+
+You can add the environment variable LAMP_LDAP_DOMAIN to the ~/.config/state/environment file. Set it with the domain name you want to bind.
+After that, restart the lamp systemd service. The complete bind credentials should be available as environment variables in the discovery.env file.
+These credentials should also be mounted as environment variables in the lamp-app container.
+
 ## Debug
 
 some CLI are needed to debug
@@ -180,35 +186,17 @@ on the root terminal
  `runagent -m lamp1`
  ```
 podman ps
-CONTAINER ID  IMAGE                                      COMMAND               CREATED        STATUS        PORTS                    NAMES
-d292c6ff28e9  localhost/podman-pause:4.6.1-1702418000                          9 minutes ago  Up 9 minutes  127.0.0.1:20015->80/tcp  80b8de25945f-infra
-d8df02bf6f4a  docker.io/library/mariadb:10.11.5          --character-set-s...  9 minutes ago  Up 9 minutes  127.0.0.1:20015->80/tcp  mariadb-app
-9e58e5bd676f  docker.io/library/nginx:stable-alpine3.17  nginx -g daemon o...  9 minutes ago  Up 9 minutes  127.0.0.1:20015->80/tcp  lamp-app
 ```
 
 you can see what environment variable is inside the container
 ```
 podman exec  lamp-app env
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-TERM=xterm
-PKG_RELEASE=1
-MARIADB_DB_HOST=127.0.0.1
-MARIADB_DB_NAME=lamp
-MARIADB_IMAGE=docker.io/mariadb:10.11.5
-MARIADB_DB_TYPE=mysql
-container=podman
-NGINX_VERSION=1.24.0
-NJS_VERSION=0.7.12
-MARIADB_DB_USER=lamp
-MARIADB_DB_PASSWORD=lamp
-MARIADB_DB_PORT=3306
-HOME=/root
 ```
 
 you can run a shell inside the container
 
 ```
-podman exec -ti   lamp-app sh
+podman exec -ti   lamp-app bash
 / # 
 ```
 ## Testing

--- a/build-images.sh
+++ b/build-images.sh
@@ -53,7 +53,7 @@ buildah add "${container}" ui/dist /ui
 # rootfull=0 === rootless container
 # tcp-ports-demand=1 number of tcp Port to reserve , 1 is the minimum, can be udp or tcp
 buildah config --entrypoint=/ \
-    --label="org.nethserver.authorizations=traefik@node:routeadm" \
+    --label="org.nethserver.authorizations=traefik@node:routeadm cluster:accountconsumer" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
     --label="org.nethserver.images=ghcr.io/stephdl/lamp-server:${IMAGETAG}" \

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -40,6 +40,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php && \
       pwgen \
       ftp \
       ftp-ssl \
+      ssmtp \
       php${PHP_VERSION}-pdo-mysql \
       php${PHP_VERSION}-mysql \
       php${PHP_VERSION}-apcu \

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -14,7 +14,7 @@ ENV BOOT2DOCKER_ID 1005
 ENV BOOT2DOCKER_GID 50
 
 ENV PHPMYADMIN_VERSION=5.2.1
-ENV SUPERVISOR_VERSION=4.2.2
+
 
 ARG PHP_VERSION
 ENV PHP_VERSION=$PHP_VERSION
@@ -33,7 +33,10 @@ RUN LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
   apt-get update && \
   apt-get -y upgrade && \
-  apt-get -y install supervisor wget git apache2 \
+  apt-get -y install supervisor \
+      wget \
+      git \
+      apache2 \
       php${PHP_VERSION}-xdebug \
       libapache2-mod-php${PHP_VERSION} \
       mariadb-server \

--- a/container/mysql_init.sh
+++ b/container/mysql_init.sh
@@ -27,45 +27,38 @@ if [[ -f "/initdb.d/lamp.sql" ]]; then
 else
     echo "=> No lamp.sql found we do the mysql init"
 
+    # if [[ -e /db/init.sql ]]; then
+    #     echo "=> Initializing the database"
+
+    #     mysql -uroot < /db/init.sql
+    # fi
+
     PASS=${MYSQL_ADMIN_PASS:-$(pwgen -s 12 1)}
     _word=$( [ ${MYSQL_ADMIN_PASS} ] && echo "preset" || echo "random" )
     echo "=> Creating MySQL admin user with password"
-
     mysql -uroot -e "CREATE USER 'admin'@'%' IDENTIFIED BY '$PASS'"
     mysql -uroot -e "GRANT ALL PRIVILEGES ON *.* TO 'admin'@'%' WITH GRANT OPTION"
     mysql -uroot -e "CREATE DATABASE IF NOT EXISTS phpmyadmin"
-    # mysql -uroot -e "CREATE USER 'pma'@'localhost' IDENTIFIED BY ''"
-    # mysql -uroot -e " GRANT ALL PRIVILEGES ON phpmyadmin.* TO  'pma'@'localhost'"
-    mysql -uroot -e "CREATE USER 'version_user'@'localhost' IDENTIFIED BY 'version_password'";
-    mysql -uroot -e "GRANT SELECT ON mysql.version TO 'version_user'@'localhost'"
 
-    # Create a new database and for phpmyadmin
+    echo "create version_user for mysql version"
+    mysql -uroot -e "CREATE USER 'version_user'@'localhost' IDENTIFIED BY 'version_password'";
+    mysql -uroot -e "GRANT USAGE ON *.* TO 'version_user'@'localhost';
+"
+
+    echo "Create a new database and for phpmyadmin"
     mysql -uroot < /var/www/phpMyAdmin-*/sql/create_tables.sql
 
-    CREATE_MYSQL_USER=false
-
-    if [ -n "$CREATE_MYSQL_BASIC_USER_AND_DB" ] || \
-    [ -n "$MYSQL_USER_NAME" ] || \
-    [ -n "$MYSQL_USER_DB" ] || \
-    [ -n "$MYSQL_USER_PASS" ]; then
-        CREATE_MYSQL_USER=true
-    fi
+    CREATE_MYSQL_USER="False"
 
     if [ "$CREATE_MYSQL_USER" == "True" ]; then
         _user=${MYSQL_USER_NAME:?}
         _userdb=${MYSQL_USER_DB:?}
         _userpass=${MYSQL_USER_PASS:?}
-
+        echo "create a new user  ${_user} with  database ${_userdb}"
         mysql -uroot -e "CREATE USER '${_user}'@'%' IDENTIFIED BY  '${_userpass}'"
         mysql -uroot -e "GRANT USAGE ON *.* TO  '${_user}'@'%' IDENTIFIED BY '${_userpass}'"
         mysql -uroot -e "CREATE DATABASE IF NOT EXISTS ${_userdb}"
         mysql -uroot -e "GRANT ALL PRIVILEGES ON ${_userdb}.* TO '${_user}'@'%'"
-    fi
-
-    if [[ -e /db/init.sql ]]; then
-        echo "=> Initializing the database"
-
-        mysql -uroot < /db/init.sql
     fi
 
     echo "=> Done!"

--- a/container/mysql_init.sh
+++ b/container/mysql_init.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e 
+# Redirect any output to the journal (stderr)
+exec 1>&2
+
 mysqld_safe --socket=/var/run/mysqld/mysqld.sock --user=root > /dev/null 2>&1 &
 RET=1
 while [[ RET -ne 0 ]]; do
@@ -47,10 +51,10 @@ else
         CREATE_MYSQL_USER=true
     fi
 
-    if [ "$CREATE_MYSQL_USER" = true ]; then
-        _user=${MYSQL_USER_NAME:-user}
-        _userdb=${MYSQL_USER_DB:-db}
-        _userpass=${MYSQL_USER_PASS:-password}
+    if [ "$CREATE_MYSQL_USER" == "True" ]; then
+        _user=${MYSQL_USER_NAME:?}
+        _userdb=${MYSQL_USER_DB:?}
+        _userpass=${MYSQL_USER_PASS:?}
 
         mysql -uroot -e "CREATE USER '${_user}'@'%' IDENTIFIED BY  '${_userpass}'"
         mysql -uroot -e "GRANT USAGE ON *.* TO  '${_user}'@'%' IDENTIFIED BY '${_userpass}'"
@@ -72,7 +76,7 @@ else
     echo "MySQL user 'root' has no password but only allows local connections"
     echo ""
 
-    if [ "$CREATE_MYSQL_USER" = true ]; then
+    if [ "$CREATE_MYSQL_USER" == "True" ]; then
         echo "We also created"
         echo "A database called '${_userdb}' and"
         echo "a user called '${_user}' with password"

--- a/container/mysql_init.sh
+++ b/container/mysql_init.sh
@@ -27,12 +27,6 @@ if [[ -f "/initdb.d/lamp.sql" ]]; then
 else
     echo "=> No lamp.sql found we do the mysql init"
 
-    # if [[ -e /db/init.sql ]]; then
-    #     echo "=> Initializing the database"
-
-    #     mysql -uroot < /db/init.sql
-    # fi
-
     PASS=${MYSQL_ADMIN_PASS:-$(pwgen -s 12 1)}
     _word=$( [ ${MYSQL_ADMIN_PASS} ] && echo "preset" || echo "random" )
     echo "=> Creating MySQL admin user with password"

--- a/container/run.sh
+++ b/container/run.sh
@@ -91,6 +91,23 @@ fi
 ln -sf /dev/stderr /var/log/apache2/access.log
 ln -sf /dev/stderr /var/log/apache2/error.log
 
+# create a .htacess file if not exists
+if [ ! -f /app/.htaccess ]; then
+    echo "Creating .htaccess file"
+    {
+        echo "# write your custom settings, uncomment or add your directives"
+        echo "# php_value max_execution_time 600"
+        echo "# php_value max_input_time 600"
+        echo "# php_value memory_limit 512M" 
+    } > /app/.htaccess
+    # set the permissions
+    chmod 644 /app/.htaccess
+    chown www-data:staff /app/.htaccess
+    echo "The .htaccess file has been created"
+else
+    echo "The .htaccess file already exists"
+fi
+
 echo "Editing phpmyadmin config"
 sed -i "s/cfg\['blowfish_secret'\] = ''/cfg['blowfish_secret'] = '`openssl rand -hex 16`'/" /var/www/phpmyadmin/config.inc.php
 

--- a/container/run.sh
+++ b/container/run.sh
@@ -102,7 +102,6 @@ if [ ! -f /app/.htaccess ]; then
     } > /app/.htaccess
     # set the permissions
     chmod 644 /app/.htaccess
-    chown www-data:staff /app/.htaccess
     echo "The .htaccess file has been created"
 else
     echo "The .htaccess file already exists"
@@ -116,9 +115,9 @@ mkdir -p /var/run/mysqld
 mkdir -p /var/log/mysql
 
 # Setup user and permissions for MySQL and Apache
-chmod -R 770 /var/lib/mysql
-chmod -R 770 /var/run/mysqld
-chmod -R 770 /var/log/mysql
+# chmod -R 770 /var/lib/mysql
+# chmod -R 770 /var/run/mysqld
+# chmod -R 770 /var/log/mysql
 touch /var/log/mysql/error.log
 
 
@@ -128,9 +127,9 @@ chown -R www-data:staff /var/www
 chown -R www-data:staff /app
 
 
-echo "Allowing Apache/PHP to write to MySQL"
-chown -R www-data:staff /var/lib/mysql
-chown -R www-data:staff /var/run/mysqld
+# echo "Allowing Apache/PHP to write to MySQL"
+# chown -R www-data:staff /var/lib/mysql
+# chown -R www-data:staff /var/run/mysqld
 # chown -R www-data:staff /var/log/mysql
 
 # Listen only on IPv4 addresses

--- a/container/run.sh
+++ b/container/run.sh
@@ -25,7 +25,7 @@ function replace_apache_php_ini_values () {
         -e "s/^max_execution_time.*/max_execution_time = ${PHP_MAX_EXECUTION_TIME}/" /etc/php/$1/apache2/php.ini
 
     sed -i "s/;date.timezone =/date.timezone = Europe\/London/g" /etc/php/$1/apache2/php.ini
-    sed -i "s/;user_ini.filename = \".user.ini\"/user_ini.filename = \".user.ini\"/g" /etc/php/$1/apache2/php.ini
+    #sed -i "s/;user_ini.filename = \".user.ini\"/user_ini.filename = \".user.ini\"/g" /etc/php/$1/apache2/php.ini
     sed -i "s|;sendmail_path =|sendmail_path = /usr/sbin/ssmtp -t|" /etc/php/$1/apache2/php.ini
 
 }

--- a/imageroot/actions/configure-module/10configure_environment_vars
+++ b/imageroot/actions/configure-module/10configure_environment_vars
@@ -8,6 +8,7 @@
 import json
 import sys
 import agent
+import os
 
 # Try to parse the stdin as JSON.
 # If parsing fails, output everything to stderr
@@ -22,3 +23,6 @@ agent.write_envfile("password.env", password)
 agent.set_env("CREATE_MYSQL_USER", data.get("create_mysql_user",False))
 agent.set_env("PHP_UPLOAD_MAX_FILESIZE", data.get("php_upload_max_filesize",'100') + 'M')
 agent.set_env("PHP_POST_MAX_SIZE", data.get("php_upload_max_filesize",'100') + 'M')
+
+# Bind the new domain, overriding previous values (unbind)
+agent.bind_user_domains([os.environ.get('LAMP_LDAP_DOMAIN','')])

--- a/imageroot/bin/discover-ldap
+++ b/imageroot/bin/discover-ldap
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+#
+# Find settings for LDAP service
+#
+
+import os
+import sys
+import json
+import agent
+from agent.ldapproxy import Ldapproxy
+
+udomname = os.environ.get('LAMP_LDAP_DOMAIN','')
+
+try:
+    odom = Ldapproxy().get_domain(udomname)
+    'host' in odom # Throw exception if odom is None
+except:
+    # During restore the domain could be unavailable. Use a fallback
+    # configuration, pointing to nowhere, just to set the variables.
+    # Once the domain becomes available, the event will fix them.
+    odom = {
+        'host': '127.0.0.1',
+        'port': 20000,
+        'schema': 'rfc2307',
+        'location': 'internal',
+        'base_dn': 'dc=lamp,dc=invalid',
+        'bind_dn': 'cn=example,dc=lamp,dc=invalid',
+        'bind_password': 'invalid',
+    }
+
+tmpfile = "discover.env." + str(os.getpid())
+
+with open(tmpfile, "w") as denv:
+    print('LAMP_LDAP_PORT=' + str(odom['port']), file=denv)
+    print('LAMP_LDAP_USER=' + odom['bind_dn'], file=denv)
+    print('LAMP_LDAP_HOST=' + odom['host'], file=denv)
+    print('LAMP_LDAP_PASS=' + odom['bind_password'], file=denv)
+    print('LAMP_LDAP_SCHEMA=' + odom['schema'], file=denv)
+    print('LAMP_LDAP_BASE=' + odom['base_dn'], file=denv)
+
+os.replace(tmpfile, "discovery.env")

--- a/imageroot/events/user-domain-changed/20configure_ldap
+++ b/imageroot/events/user-domain-changed/20configure_ldap
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import agent
+import os
+
+event = json.load(sys.stdin)
+
+if event.get('domain') != os.getenv('LAMP_LDAP_DOMAIN'):
+    exit(0)
+
+if 'node' in event and str(event['node']) != os.getenv('NODE_ID'):
+    exit(0) # ignore event if the source is not in our node
+
+agent.run_helper('systemctl', '--user', '-T', 'try-reload-or-restart', 'lamp.service').check_returncode()

--- a/imageroot/systemd/user/lamp-app.service
+++ b/imageroot/systemd/user/lamp-app.service
@@ -27,6 +27,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/lamp-app.pid \
     --volume mysql:/var/lib/mysql:Z \
     --volume app:/app:Z \
     --volume ./initdb.d:/initdb.d:Z \
+    --env SMTP_* \
     --env CREATE_MYSQL_USER=${CREATE_MYSQL_USER} \
     --env MYSQL_USER_NAME=${MYSQL_USER_NAME} \
     --env MYSQL_USER_DB=${MYSQL_USER_DB} \

--- a/imageroot/systemd/user/lamp-app.service
+++ b/imageroot/systemd/user/lamp-app.service
@@ -28,6 +28,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/lamp-app.pid \
     --volume app:/app:Z \
     --volume ./initdb.d:/initdb.d:Z \
     --env SMTP_* \
+    --env LAMP_* \
     --env CREATE_MYSQL_USER=${CREATE_MYSQL_USER} \
     --env MYSQL_USER_NAME=${MYSQL_USER_NAME} \
     --env MYSQL_USER_DB=${MYSQL_USER_DB} \

--- a/imageroot/systemd/user/lamp-app.service
+++ b/imageroot/systemd/user/lamp-app.service
@@ -13,11 +13,13 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
 EnvironmentFile=%S/state/password.env
 EnvironmentFile=-%S/state/smarthost.env
+EnvironmentFile=-%S/state/discovery.env
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/lamp-app.pid %t/lamp-app.ctr-id
 ExecStartPre=-runagent discover-smarthost
+ExecStartPre=-runagent discover-ldap
 ExecStartPre=/bin/mkdir -vp initdb.d
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/lamp-app.pid \
     --cidfile %t/lamp-app.ctr-id --cgroups=no-conmon \


### PR DESCRIPTION
This pull request updates the PHP configuration to use ssmtp for sending emails. It adds the `ssmtp` package to the PHP container and modifies the `php.ini` file to use the `ssmtp -t` command for sending emails. This ensures that all emails sent by different applications or scripts will be routed through ssmtp. Additionally, a sample PHP script is provided to test the email functionality.

additionnaly we have the autodiscovery ldap script enabled