### PR TITLE
Enable remote IP module in Apache configuration

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -118,6 +118,7 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&
 # config to enable .htaccess
 ADD apache_default /etc/apache2/sites-available/000-default.conf
 RUN a2enmod rewrite
+RUN a2enmod remoteip
 
 # Configure /app folder with sample app
 RUN mkdir -p /app && rm -fr /var/www/html && ln -s /app /var/www/html

--- a/container/apache_default
+++ b/container/apache_default
@@ -43,7 +43,8 @@
 
     <IfModule remoteip_module>
         RemoteIPHeader X-Forwarded-For
-        RemoteIPInternalProxy 10.0.0.0/8 # Example, replace with your internal network
+        RemoteIPTrustedProxy 127.0.0.1
+        RemoteIPTrustedProxy 10.0.0.0/8
     </IfModule>
 
 </VirtualHost>

--- a/container/apache_default
+++ b/container/apache_default
@@ -41,5 +41,9 @@
     # channel.
     SetEnvIf x-forwarded-proto https HTTPS=on
 
-</VirtualHost>
+    <IfModule remoteip_module>
+        RemoteIPHeader X-Forwarded-For
+        RemoteIPInternalProxy 10.0.0.0/8 # Example, replace with your internal network
+    </IfModule>
 
+</VirtualHost>


### PR DESCRIPTION
This pull request enables the remote IP module in the Apache configuration. It adds the necessary configuration to the Apache default file to enable the module and sets the appropriate headers for handling X-Forwarded-For.