### PR TITLE
Log mysql to stderr and use the mysql user

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -148,18 +148,9 @@ RUN echo "Editing APACHE_RUN_GROUP environment variable" && \
 RUN echo "Setting up MySQL directories" && \
         mkdir -p /var/run/mysqld && \
         mkdir -p /var/log/mysql && \
-        touch /var/log/mysql/error.log
+        chown -R mysql:mysql /var/run/mysqld && \
+        chown -R mysql:mysql /var/log/mysql
 
-RUN echo "Editing MySQL config" && \
-        sed -i "s/.*bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf && \
-        sed -i "s/.*bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mariadb.conf.d/50-server.cnf && \
-        sed -i "s/user.*/user = www-data/" /etc/mysql/mariadb.conf.d/50-server.cnf && \
-        sed -i "s|#log_error = /var/log/mysql/error.log|log_error = /var/log/mysql/error.log|" /etc/mysql/mariadb.conf.d/50-server.cnf && \
-        sed -i "s/skip_log_error/#skip_log_error/" /etc/mysql/mariadb.conf.d/50-mysqld_safe.cnf && \
-        sed -i "s/syslog/#syslog/" /etc/mysql/mariadb.conf.d/50-mysqld_safe.cnf
-
-RUN echo "# log mysql to stderr" && \
-        ln -sf /dev/stderr /var/log/mysql/error.log
 # clean up
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/container/mysql_init.sh
+++ b/container/mysql_init.sh
@@ -4,7 +4,7 @@ set -e
 # Redirect any output to the journal (stderr)
 exec 1>&2
 
-mysqld_safe --socket=/var/run/mysqld/mysqld.sock --user=root > /dev/null 2>&1 &
+mysqld_safe --socket=/var/run/mysqld/mysqld.sock --user=mysql > /dev/null 2>&1 &
 RET=1
 while [[ RET -ne 0 ]]; do
     echo "=> Waiting for confirmation of MySQL service startup"

--- a/container/run.sh
+++ b/container/run.sh
@@ -68,7 +68,7 @@ fi
 echo "Editing Mysql config"
 if [ -e /var/run/mysqld/mysqld.sock ];then
     echo "Removing MySQL socket"
-    rm /var/run/mysqld/mysqld.sock
+    rm -f /var/run/mysqld/mysqld.sock
 fi
 
 
@@ -77,7 +77,7 @@ if [[ ! -d /var/lib/mysql/mysql ]]; then
     echo "=> Installing or restoring MySQL ..."
 
     # Try the 'preferred' solution
-    mariadb-install-db --user=root --auth-root-authentication-method=socket --skip-test-db 
+    mariadb-install-db --user=mysql --auth-root-authentication-method=socket --skip-test-db 
     if [ $? -ne 0 ]; then
         # Fall back to the 'depreciated' solution
         mysql_install_db > /dev/null 2>&1

--- a/container/start-mysqld.sh
+++ b/container/start-mysqld.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec /usr/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/bin/mysqld_safe --user=root

--- a/container/supervisord-mysqld.conf
+++ b/container/supervisord-mysqld.conf
@@ -1,5 +1,5 @@
 [program:mysqld]
-command=/start-mysqld.sh
+command=/usr/sbin/mariadbd --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib/mysql/plugin --user=mysql --skip-log-error --pid-file=/var/run/mysqld/mysqld.pid --socket=/run/mysqld/mysqld.sock
 numprocs=1
 autostart=true
 autorestart=true


### PR DESCRIPTION
The pull request includes changes to log MySQL directly to stderr. This is achieved by modifying the MySQL configuration file and the startup script. The changes ensure that MySQL logs are redirected to stderr instead of a file.

Furthermore the root user is not used anymore to run mariadb service, the mysql user is used instead 