### PR TITLE
Add volume mounts for MySQL configuration files

### DIFF
--- a/imageroot/systemd/user/lamp-app.service
+++ b/imageroot/systemd/user/lamp-app.service
@@ -21,12 +21,15 @@ ExecStartPre=/bin/rm -f %t/lamp-app.pid %t/lamp-app.ctr-id
 ExecStartPre=-runagent discover-smarthost
 ExecStartPre=-runagent discover-ldap
 ExecStartPre=/bin/mkdir -vp initdb.d
+ExecStartPre=/bin/mkdir -vp conf.d
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/lamp-app.pid \
     --cidfile %t/lamp-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/lamp.pod-id --replace -d --name  lamp-app \
     --volume mysql:/var/lib/mysql:Z \
     --volume app:/app:Z \
     --volume ./initdb.d:/initdb.d:Z \
+    --volume ./conf.d/mysql.cnf:/etc/mysql/conf.d/mysql.cnf:Z \
+    --volume ./conf.d/mysqldump.cnf:/etc/mysql/conf.d/mysqldump.cnf:Z \
     --env SMTP_* \
     --env LAMP_* \
     --env CREATE_MYSQL_USER=${CREATE_MYSQL_USER} \


### PR DESCRIPTION
This pull request adds volume mounts for MySQL configuration files. Specifically, it creates directories for `conf.d` and mounts `mysql.cnf` and `mysqldump.cnf` into the appropriate locations in the container. This allows for easy customization and configuration of MySQL within the container.