### PR TITLE
Enable phpMyAdmin based on PHPMYADMIN_ENABLED flag

### DIFF
--- a/container/run.sh
+++ b/container/run.sh
@@ -49,6 +49,13 @@ echo "Updating settings for PHP ${PHP_VERSION}" && \
 echo "Editing phpmyadmin config" && \
     sed -i "s/cfg\['blowfish_secret'\] = ''/cfg['blowfish_secret'] = '`openssl rand -hex 16`'/" /var/www/phpmyadmin/config.inc.php
 
+# Check if phpMyAdmin is enabled
+if [[ "$PHPMYADMIN_ENABLED" != "True" ]]; then
+    echo "Disabling phpMyAdmin"
+    sed -i "s|Alias /phpmyadmin /var/www/phpmyadmin|# phpmyadmin disabled|" /etc/apache2/sites-available/000-default.conf
+else
+    echo "Enabling phpMyAdmin"
+fi
 # create a .htacess file if not exists
 if [ ! -f /app/.htaccess ]; then
     echo "Creating .htaccess file"

--- a/imageroot/actions/clone-module/50configure
+++ b/imageroot/actions/clone-module/50configure
@@ -18,5 +18,6 @@ configure_retval = agent.tasks.run(agent_id=os.environ['AGENT_ID'], action='conf
     "mysql_admin_pass": agent.read_envfile("password.env")["MYSQL_ADMIN_PASS"],
     "mysql_user_pass": agent.read_envfile("password.env")["MYSQL_USER_PASS"],
     "php_upload_max_filesize": os.environ["PHP_UPLOAD_MAX_FILESIZE"].removesuffix('M'),
+    "phpmyadmin_enabled": os.environ["PHPMYADMIN_ENABLED"] == "True",
 })
 agent.assert_exp(configure_retval['exit_code'] == 0, "The configure-module subtask failed!")

--- a/imageroot/actions/configure-module/10configure_environment_vars
+++ b/imageroot/actions/configure-module/10configure_environment_vars
@@ -23,6 +23,7 @@ agent.write_envfile("password.env", password)
 agent.set_env("CREATE_MYSQL_USER", data.get("create_mysql_user",False))
 agent.set_env("PHP_UPLOAD_MAX_FILESIZE", data.get("php_upload_max_filesize",'100') + 'M')
 agent.set_env("PHP_POST_MAX_SIZE", data.get("php_upload_max_filesize",'100') + 'M')
+agent.set_env("PHPMYADMIN_ENABLED", data.get("phpmyadmin_enabled",True))
 
 # Bind the new domain, overriding previous values (unbind)
 agent.bind_user_domains([os.environ.get('LAMP_LDAP_DOMAIN','')])

--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -14,7 +14,7 @@
       "mysql_user_db": "database",
       "create_mysql_user": true,
       "php_upload_max_filesize": "100M",
-      "phmyadmin_enabled": true
+      "phpmyadmin_enabled": true
     }
   ],
   "type": "object",
@@ -28,7 +28,7 @@
     "mysql_user_db",
     "create_mysql_user",
     "php_upload_max_filesize",
-    "phmyadmin_enabled"
+    "phpmyadmin_enabled"
   ],
   "properties": {
     "host": {
@@ -77,7 +77,7 @@
       "title": "PHP upload max filesize",
       "description": "Maximum size of uploaded files"
     },
-    "phmyadmin_enabled": {
+    "phpmyadmin_enabled": {
       "type": "boolean",
       "title": "phpMyAdmin enabled",
       "description": "Enable phpMyAdmin"

--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -13,7 +13,8 @@
       "mysql_admin_pass": "password",
       "mysql_user_db": "database",
       "create_mysql_user": true,
-      "php_upload_max_filesize": "100M"
+      "php_upload_max_filesize": "100M",
+      "phmyadmin_enabled": true
     }
   ],
   "type": "object",
@@ -26,7 +27,8 @@
     "mysql_admin_pass",
     "mysql_user_db",
     "create_mysql_user",
-    "php_upload_max_filesize"
+    "php_upload_max_filesize",
+    "phmyadmin_enabled"
   ],
   "properties": {
     "host": {
@@ -74,6 +76,11 @@
       "type": "string",
       "title": "PHP upload max filesize",
       "description": "Maximum size of uploaded files"
+    },
+    "phmyadmin_enabled": {
+      "type": "boolean",
+      "title": "phpMyAdmin enabled",
+      "description": "Enable phpMyAdmin"
     }
   }
 }

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -32,5 +32,7 @@ config["mysql_user_pass"] = agent.read_envfile("password.env")["MYSQL_USER_PASS"
 
 config["create_mysql_user"] = os.getenv("CREATE_MYSQL_USER","False") == "True"
 config["php_upload_max_filesize"] = os.getenv("PHP_UPLOAD_MAX_FILESIZE","100").removesuffix('M')
+config["phpmyadmin_enabled"] = os.getenv("PHPMYADMIN_ENABLED","True") == "True"
+
 # Dump the configuration to stdout
 json.dump(config, fp=sys.stdout)

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -14,7 +14,7 @@
       "mysql_user_db": "database",
       "create_mysql_user": true,
       "php_upload_max_filesize": "100M",
-      "phmyadmin_enabled": true
+      "phpmyadmin_enabled": true
     }
   ],
   "type": "object",
@@ -28,7 +28,7 @@
     "mysql_user_db",
     "create_mysql_user",
     "php_upload_max_filesize",
-    "phmyadmin_enabled"
+    "phpmyadmin_enabled"
   ],
   "properties": {
     "host": {
@@ -75,7 +75,7 @@
       "title": "PHP upload max filesize",
       "description": "PHP upload max filesize"
     },
-    "phmyadmin_enabled": {
+    "phpmyadmin_enabled": {
       "type": "boolean",
       "title": "Enable phpMyAdmin",
       "description": "Enable phpMyAdmin"

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -13,7 +13,8 @@
       "mysql_admin_pass": "password",
       "mysql_user_db": "database",
       "create_mysql_user": true,
-      "php_upload_max_filesize": "100M"
+      "php_upload_max_filesize": "100M",
+      "phmyadmin_enabled": true
     }
   ],
   "type": "object",
@@ -26,7 +27,8 @@
     "mysql_admin_pass",
     "mysql_user_db",
     "create_mysql_user",
-    "php_upload_max_filesize"
+    "php_upload_max_filesize",
+    "phmyadmin_enabled"
   ],
   "properties": {
     "host": {
@@ -72,6 +74,11 @@
       "type": "string",
       "title": "PHP upload max filesize",
       "description": "PHP upload max filesize"
+    },
+    "phmyadmin_enabled": {
+      "type": "boolean",
+      "title": "Enable phpMyAdmin",
+      "description": "Enable phpMyAdmin"
     }
   }
 }

--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -20,7 +20,8 @@ for evar in [
         "MYSQL_USER_NAME",
         "MYSQL_USER_DB",
         "CREATE_MYSQL_USER",
-        "PHP_UPLOAD_MAX_FILESIZE"
+        "PHP_UPLOAD_MAX_FILESIZE",
+        "PHPMYADMIN_ENABLED",
     ]:
     agent.set_env(evar, original_environment[evar])
 

--- a/imageroot/actions/restore-module/50configure
+++ b/imageroot/actions/restore-module/50configure
@@ -23,5 +23,6 @@ configure_retval = agent.tasks.run(agent_id=os.environ['AGENT_ID'], action='conf
     "mysql_admin_pass": agent.read_envfile("password.env")["MYSQL_ADMIN_PASS"],
     "mysql_user_pass": agent.read_envfile("password.env")["MYSQL_USER_PASS"],
     "php_upload_max_filesize": renv["PHP_UPLOAD_MAX_FILESIZE"].removesuffix('M'),
+    "phpmyadmin_enabled": renv["PHPMYADMIN_ENABLED"] == "True",
 })
 agent.assert_exp(configure_retval['exit_code'] == 0, "The configure-module subtask failed!")

--- a/imageroot/systemd/user/lamp-app.service
+++ b/imageroot/systemd/user/lamp-app.service
@@ -38,6 +38,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/lamp-app.pid \
     --env MYSQL_ADMIN_PASS=${MYSQL_ADMIN_PASS} \
     --env PHP_POST_MAX_SIZE=${PHP_UPLOAD_MAX_FILESIZE} \
     --env PHP_UPLOAD_MAX_FILESIZE=${PHP_UPLOAD_MAX_FILESIZE} \
+    --env PHPMYADMIN_ENABLED=${PHPMYADMIN_ENABLED} \
     ${LAMP_SERVER_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/lamp-app.ctr-id -t 10
 ExecReload=/usr/bin/podman kill -s HUP lamp-app

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -63,10 +63,8 @@
     "mysql_user_db": "MySQL database name",
     "mysql_user_db_placeholder": "Enter MySQL database name",
     "mysql_user_db_tooltip": "Name of the MySQL database to create",
-    "mysql_user_db_helper": "This database cannot be changed from the UI once set"
-
-
-
+    "mysql_user_db_helper": "This database cannot be changed from the UI once set",
+    "phmyadmin_enabled": "Enable phpMyAdmin"
   },
   "about": {
     "title": "About"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -26,7 +26,8 @@
     "configure": "Configure",
     "open_phpmyadmin": "Open phpMyAdmin",
     "configure_mysql_database": "Configure MySQL database",
-    "lamp_phpmyadmin": "lamp phpMyAdmin"
+    "lamp_phpmyadmin": "lamp phpMyAdmin",
+    "phpmyadmin_disabled": "phpMyAdmin is disabled"
   },
   "settings": {
     "title": "Settings",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -64,7 +64,7 @@
     "mysql_user_db_placeholder": "Enter MySQL database name",
     "mysql_user_db_tooltip": "Name of the MySQL database to create",
     "mysql_user_db_helper": "This database cannot be changed from the UI once set",
-    "phmyadmin_enabled": "Enable phpMyAdmin"
+    "phpmyadmin_enabled": "Enable phpMyAdmin"
   },
   "about": {
     "title": "About"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -85,6 +85,22 @@
                 <template slot="title">{{ $t("settings.advanced") }}</template>
                 <template slot="content">
                   <cv-toggle
+                    value="phpmyadmin_enabled"
+                    :label="$t('settings.phpmyadmin_enabled')"
+                    v-model="phpmyadmin_enabled"
+                    :disabled="
+                      loading.getConfiguration || loading.configureModule
+                    "
+                    class="mg-bottom"
+                  >
+                    <template slot="text-left">{{
+                      $t("settings.disabled")
+                    }}</template>
+                    <template slot="text-right">{{
+                      $t("settings.enabled")
+                    }}</template>
+                  </cv-toggle>
+                  <cv-toggle
                     value="create_mysql_user"
                     :label="$t('settings.create_mysql_user')"
                     v-model="create_mysql_user"
@@ -160,10 +176,11 @@
                     :label="$t('settings.php_upload_max_filesize')"
                     v-model="php_upload_max_filesize"
                     type="number"
-                    :placeholder="$t('settings.php_upload_max_filesize_placeholder')"
+                    :placeholder="
+                      $t('settings.php_upload_max_filesize_placeholder')
+                    "
                     :disabled="
-                      loading.getConfiguration ||
-                      loading.configureModule
+                      loading.getConfiguration || loading.configureModule
                     "
                     :invalid-message="$t(error.php_upload_max_filesize)"
                     ref="php_upload_max_filesize"
@@ -232,6 +249,7 @@ export default {
       host: "",
       isLetsEncryptEnabled: false,
       isHttpToHttpsEnabled: true,
+      phpmyadmin_enabled: true,
       create_mysql_user: false,
       php_upload_max_filesize: "100",
       mysql_user_name: "",
@@ -329,6 +347,7 @@ export default {
       this.loading.getConfiguration = false;
       this.create_mysql_user = config.create_mysql_user;
       this.php_upload_max_filesize = config.php_upload_max_filesize;
+      this.phpmyadmin_enabled = config.phpmyadmin_enabled;
       this.focusElement("host");
     },
     validateConfigureModule() {
@@ -450,6 +469,7 @@ export default {
             mysql_admin_pass: this.mysql_admin_pass,
             create_mysql_user: this.create_mysql_user,
             php_upload_max_filesize: this.php_upload_max_filesize,
+            phpmyadmin_enabled: this.phpmyadmin_enabled,
           },
           extra: {
             title: this.$t("settings.instance_configuration", {

--- a/ui/src/views/Status.vue
+++ b/ui/src/views/Status.vue
@@ -79,7 +79,7 @@
           <NsInfoCard
             light
             :title="$t('status.lamp_phpmyadmin')"
-            :description="$t('status.configure_mysql_database')"
+            :description="phpmyadmin ? $t('status.configure_mysql_database') : $t('status.phpmyadmin_disabled')"
             :icon="Wikis32"
             :loading="loading.getConfiguration"
             :isErrorShown="error.getConfiguration"
@@ -90,6 +90,7 @@
             <template slot="content">
               <NsButton
                 kind="ghost"
+                v-if="phpmyadmin_enabled"
                 :icon="Launch20"
                 :disabled="loading.getConfiguration"
                 @click="goToWebphpmyadmin"
@@ -343,6 +344,7 @@ export default {
       isRedirectChecked: false,
       redirectTimeout: 0,
       host: "",
+      phpmyadmin_enabled: true,
       status: {
         instance: "",
         services: [],
@@ -461,6 +463,7 @@ export default {
     getConfigurationCompleted(taskContext, taskResult) {
       const config = taskResult.output;
       this.host = config.host;
+      this.phpmyadmin_enabled = config.phpmyadmin_enabled;
       this.loading.getConfiguration = false;
     },
     async getStatus() {


### PR DESCRIPTION
This pull request enables or disables phpMyAdmin based on the value of the `PHPMYADMIN_ENABLED` flag. The `run.sh` script has been updated to check the flag and enable or disable phpMyAdmin accordingly. The `lamp-app.service` file has also been updated to pass the `PHPMYADMIN_ENABLED` environment variable to the container. Additionally, the `Settings.vue` file has been modified to include a toggle for enabling or disabling phpMyAdmin in the UI. The `translation.json` file has been updated to include a translation for the phpMyAdmin toggle label.