### PR TITLE
Refactor phpMyAdmin configuration

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -45,6 +45,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php && \
       nano \
       wget \
       git \
+      tree \
       apache2 \
       libapache2-mod-php${PHP_VERSION} \
       mariadb-server \

--- a/container/run.sh
+++ b/container/run.sh
@@ -50,7 +50,7 @@ echo "Editing phpmyadmin config" && \
     sed -i "s/cfg\['blowfish_secret'\] = ''/cfg['blowfish_secret'] = '`openssl rand -hex 16`'/" /var/www/phpmyadmin/config.inc.php
 
 # Check if phpMyAdmin is enabled
-if [[ "$PHPMYADMIN_ENABLED" != "True" ]]; then
+if [[ "$PHPMYADMIN_ENABLED" == "False" ]]; then
     echo "Disabling phpMyAdmin"
     sed -i "s|Alias /phpmyadmin /var/www/phpmyadmin|# phpmyadmin disabled|" /etc/apache2/sites-available/000-default.conf
 else

--- a/ui/src/views/Status.vue
+++ b/ui/src/views/Status.vue
@@ -79,7 +79,7 @@
           <NsInfoCard
             light
             :title="$t('status.lamp_phpmyadmin')"
-            :description="phpmyadmin ? $t('status.configure_mysql_database') : $t('status.phpmyadmin_disabled')"
+            :description="phpmyadmin_enabled ? $t('status.configure_mysql_database') : $t('status.phpmyadmin_disabled')"
             :icon="Wikis32"
             :loading="loading.getConfiguration"
             :isErrorShown="error.getConfiguration"


### PR DESCRIPTION
This pull request refactors the phpMyAdmin configuration in the `run.sh` and `Status.vue` files. In the `run.sh` file, the code has been updated to disable phpMyAdmin if the `PHPMYADMIN_ENABLED` variable is set to "False". In the `Status.vue` file, the code has been updated to use the `phpmyadmin_enabled` variable instead of the `phpmyadmin` variable for displaying the description. These changes improve the configuration and handling of phpMyAdmin in the application.