### PR TITLE
start the name with apache2 to be crowdsec compatible

### DIFF
--- a/imageroot/systemd/user/lamp-app.service
+++ b/imageroot/systemd/user/lamp-app.service
@@ -23,7 +23,7 @@ ExecStartPre=-runagent discover-ldap
 ExecStartPre=/bin/mkdir -vp initdb.d
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/lamp-app.pid \
     --cidfile %t/lamp-app.ctr-id --cgroups=no-conmon \
-    --pod-id-file %t/lamp.pod-id --replace -d --name  lamp-app \
+    --pod-id-file %t/lamp.pod-id --replace -d --name  apache2-lamp-app \
     --volume mysql:/var/lib/mysql:Z \
     --volume app:/app:Z \
     --volume ./initdb.d:/initdb.d:Z \


### PR DESCRIPTION
for crowdsec with apache2 collection, crowdsec expects the name in journald starts with `apache2`. 