### PR TITLE
Rename lamp-app to apache2-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ NS8-LAMP is a containerized environment that encapsulates the LAMP stack, which 
 Use the /app directory as the storage location for your web application. You can access it by running the following command:
 
 
-    runagent -m lamp1 podman exec -ti apache2-lamp-app bash
+    runagent -m lamp1 podman exec -ti apache2-app bash
 or
 ```
     runagent -m lamp1
-    podman exec -ti apache2-lamp-app bash
+    podman exec -ti apache2-app bash
 ```
 
 Once inside the container, navigate to the /app directory:
@@ -61,7 +61,7 @@ Once you have saved the FQDN in the user interface, in your browser, go to https
 
 - Access the container to download the web application.
 
-`runagent -m lamp1 podman exec -ti apache2-lamp-app bash`
+`runagent -m lamp1 podman exec -ti apache2-app bash`
 
 - go to the web folder within the container.
   
@@ -128,17 +128,17 @@ once modified you have to restart the container
 
 check by:
 
-`podman exec -ti apache2-lamp-app mysql --print-defaults`
+`podman exec -ti apache2-app mysql --print-defaults`
 
 The `mysql --print-defaults` command only shows the options that would be used for the client, not for the MySQL server (mysqld).
 
 to see the default options of mysql server do:
 
-`podman exec -ti apache2-lamp-app mysqld --print-defaults`
+`podman exec -ti apache2-app mysqld --print-defaults`
 
 alternatively you can connect directly to the container and modify
 
-`podman exec -ti apache2-lamp-app bash`
+`podman exec -ti apache2-app bash`
 
 ```
 nano /etc/mysql/conf.d/myqsl.cnf
@@ -277,7 +277,7 @@ check if everything is correctly written
 
 ```
 cat discovery.env
-podman exec -ti apache2-lamp-app env
+podman exec -ti apache2-app env
 ```
 
 ## Debug
@@ -307,13 +307,13 @@ podman ps
 
 you can see what environment variable is inside the container
 ```
-podman exec  apache2-lamp-app env
+podman exec  apache2-app env
 ```
 
 you can run a shell inside the container
 
 ```
-podman exec -ti   apache2-lamp-app bash
+podman exec -ti   apache2-app bash
 / # 
 ```
 ## Testing

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ execute it by : `php /path/2/script`
 
 You can add the environment variable `LAMP_LDAP_DOMAIN` to the `~/.config/state/environment` file. Set it with the domain name you want to bind.
 After that, restart the lamp systemd service. The complete bind credentials should be available as environment variables in the discovery.env file.
-These credentials should also be mounted as environment variables in the lamp-app container.
+These credentials should also be mounted as environment variables in the apache2-app container.
 
 to modify:
 

--- a/container/mysql_init.sh
+++ b/container/mysql_init.sh
@@ -54,7 +54,7 @@ else
     echo "=> Done!"
 
     echo "========================================================================"
-    echo "You can now connect to this MySQL Server using: podman exec -ti lamp-app mysql"
+    echo "You can now connect to this MySQL Server using: podman exec -ti apache2-app mysql"
     echo ""
     echo "MySQL user 'root' has no password but only allows local connections"
     echo ""

--- a/imageroot/bin/module-dump-state
+++ b/imageroot/bin/module-dump-state
@@ -11,7 +11,7 @@ if ! systemctl --user -q is-active lamp.service; then
     exit 0
 fi
 
-podman exec lamp-app mysqldump \
+podman exec apache2-app mysqldump \
         --all-databases \
         --default-character-set=utf8mb4 \
         --skip-dump-date \

--- a/imageroot/systemd/user/apache2-app.service
+++ b/imageroot/systemd/user/apache2-app.service
@@ -17,12 +17,12 @@ EnvironmentFile=-%S/state/discovery.env
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/lamp-app.pid %t/lamp-app.ctr-id
+ExecStartPre=/bin/rm -f %t/apache2-app.pid %t/apache2-app.ctr-id
 ExecStartPre=-runagent discover-smarthost
 ExecStartPre=-runagent discover-ldap
 ExecStartPre=/bin/mkdir -vp initdb.d
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/lamp-app.pid \
-    --cidfile %t/lamp-app.ctr-id --cgroups=no-conmon \
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/apache2-app.pid \
+    --cidfile %t/apache2-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/lamp.pod-id --replace -d --name  apache2-app \
     --volume mysql:/var/lib/mysql:Z \
     --volume app:/app:Z \
@@ -40,11 +40,11 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/lamp-app.pid \
     --env PHP_UPLOAD_MAX_FILESIZE=${PHP_UPLOAD_MAX_FILESIZE} \
     --env PHPMYADMIN_ENABLED=${PHPMYADMIN_ENABLED} \
     ${LAMP_SERVER_IMAGE}
-ExecStop=/usr/bin/podman stop --ignore --cidfile %t/lamp-app.ctr-id -t 10
-ExecReload=/usr/bin/podman kill -s HUP lamp-app
+ExecStop=/usr/bin/podman stop --ignore --cidfile %t/apache2-app.ctr-id -t 10
+ExecReload=/usr/bin/podman kill -s HUP apache2-app
 SyslogIdentifier=%u
-ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/lamp-app.ctr-id
-PIDFile=%t/lamp-app.pid
+ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/apache2-app.ctr-id
+PIDFile=%t/apache2-app.pid
 Type=forking
 
 [Install]

--- a/imageroot/systemd/user/apache2-app.service
+++ b/imageroot/systemd/user/apache2-app.service
@@ -4,7 +4,7 @@
 #
 
 [Unit]
-Description=Podman  lamp-app.service
+Description=Podman  apache2-app.service
 BindsTo=lamp.service
 After=lamp.service
 
@@ -23,7 +23,7 @@ ExecStartPre=-runagent discover-ldap
 ExecStartPre=/bin/mkdir -vp initdb.d
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/lamp-app.pid \
     --cidfile %t/lamp-app.ctr-id --cgroups=no-conmon \
-    --pod-id-file %t/lamp.pod-id --replace -d --name  apache2-lamp-app \
+    --pod-id-file %t/lamp.pod-id --replace -d --name  apache2-app \
     --volume mysql:/var/lib/mysql:Z \
     --volume app:/app:Z \
     --volume ./initdb.d:/initdb.d:Z \

--- a/imageroot/systemd/user/lamp.service
+++ b/imageroot/systemd/user/lamp.service
@@ -10,8 +10,8 @@
 
 [Unit]
 Description=Podman lamp.service
-Requires=lamp-app.service
-Before=lamp-app.service
+Requires=apache2-app.service
+Before=apache2-app.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n

--- a/imageroot/update-module.d/20restart
+++ b/imageroot/update-module.d/20restart
@@ -12,4 +12,10 @@ set -e
 # Redirect any output to the journal (stderr)
 exec 1>&2
 
+# Remove old service
+if [ -f ../systemd/user/lamp-app.service ]; then
+    systemctl --user stop lamp-app.service
+    rm ../systemd/user/lamp-app.service
+fi
+# Restart service
 systemctl --user try-restart lamp.service


### PR DESCRIPTION
This pull request renames the `lamp-app` to `apache2-app` and updates all the references in the `README.md` and systemd service files. It fixes also the backup part