### PR TITLE
Add PHP memory limit configuration

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -115,7 +115,9 @@ RUN echo "Updating settings for PHP ${PHP_VERSION}" && \
         -e "s/^max_execution_time.*/max_execution_time = ${PHP_MAX_EXECUTION_TIME}/" /etc/php/${PHP_VERSION}/apache2/php.ini \
         -e "s/^;date.timezone.*/date.timezone = Europe\/London/" /etc/php/${PHP_VERSION}/apache2/php.ini \
         -e "s|;sendmail_path =|sendmail_path = /usr/sbin/ssmtp -t|" /etc/php/${PHP_VERSION}/apache2/php.ini \
-        -e  "s/;date.timezone =/date.timezone = UTC/g" /etc/php/${PHP_VERSION}/cli/php.ini
+        -e  "s/;date.timezone =/date.timezone = UTC/g" /etc/php/${PHP_VERSION}/cli/php.ini \
+        -e "s|^;error_log = syslog|error_log = /dev/stderr|" /etc/php/${PHP_VERSION}/apache2/php.ini \
+        -e "s|^;error_log = syslog|error_log = /dev/stderr|" /etc/php/${PHP_VERSION}/cli/php.ini
 
 # Add composer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -109,7 +109,7 @@ RUN ln -s /var/www/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages /var/www/phpmy
 RUN mv /var/www/phpmyadmin/config.sample.inc.php /var/www/phpmyadmin/config.inc.php
 
 RUN echo "Updating settings for PHP ${PHP_VERSION}" && \
-        sed -ri -e "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}/" \
+        sed -ri -e "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}/" /etc/php/${PHP_VERSION}/apache2/php.ini \
         -e "s/^post_max_size.*/post_max_size = ${PHP_POST_MAX_SIZE}/" /etc/php/${PHP_VERSION}/apache2/php.ini \
         -e "s/^memory_limit.*/memory_limit = ${PHP_MEMORY_LIMIT}/" /etc/php/${PHP_VERSION}/apache2/php.ini \
         -e "s/^max_execution_time.*/max_execution_time = ${PHP_MAX_EXECUTION_TIME}/" /etc/php/${PHP_VERSION}/apache2/php.ini \

--- a/container/run.sh
+++ b/container/run.sh
@@ -39,12 +39,17 @@ else
     echo "ssmtp.conf has been configured."
 fi
 
-echo "Updating settings for PHP ${PHP_VERSION}" && \
-    sed -ri -e "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}/" \
+echo "Updating settings for PHP APACHE ${PHP_VERSION}" && \
+    sed -ri -e "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}/" /etc/php/${PHP_VERSION}/apache2/php.ini \
     -e "s/^post_max_size.*/post_max_size = ${PHP_POST_MAX_SIZE}/" /etc/php/${PHP_VERSION}/apache2/php.ini \
     -e "s/^memory_limit.*/memory_limit = ${PHP_MEMORY_LIMIT}/" /etc/php/${PHP_VERSION}/apache2/php.ini \
     -e "s/^max_execution_time.*/max_execution_time = ${PHP_MAX_EXECUTION_TIME}/" /etc/php/${PHP_VERSION}/apache2/php.ini
 
+echo "Updating settings for PHP CLI ${PHP_VERSION}" && \
+    sed -ri -e "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}/" /etc/php/${PHP_VERSION}/cli/php.ini \
+    -e "s/^post_max_size.*/post_max_size = ${PHP_POST_MAX_SIZE}/" /etc/php/${PHP_VERSION}/cli/php.ini \
+    -e "s/^memory_limit.*/memory_limit = ${PHP_MEMORY_LIMIT}/" /etc/php/${PHP_VERSION}/cli/php.ini \
+    -e "s/^max_execution_time.*/max_execution_time = ${PHP_MAX_EXECUTION_TIME}/" /etc/php/${PHP_VERSION}/cli/php.ini
 
 echo "Editing phpmyadmin config" && \
     sed -i "s/cfg\['blowfish_secret'\] = ''/cfg['blowfish_secret'] = '`openssl rand -hex 16`'/" /var/www/phpmyadmin/config.inc.php

--- a/imageroot/actions/configure-module/10configure_environment_vars
+++ b/imageroot/actions/configure-module/10configure_environment_vars
@@ -23,6 +23,7 @@ agent.write_envfile("password.env", password)
 agent.set_env("CREATE_MYSQL_USER", data.get("create_mysql_user",False))
 agent.set_env("PHP_UPLOAD_MAX_FILESIZE", data.get("php_upload_max_filesize",'100') + 'M')
 agent.set_env("PHP_POST_MAX_SIZE", data.get("php_upload_max_filesize",'100') + 'M')
+agent.set_env("PHP_MEMORY_LIMIT", data.get("php_memory_limit",'512') + 'M')
 agent.set_env("PHPMYADMIN_ENABLED", data.get("phpmyadmin_enabled",True))
 
 # Bind the new domain, overriding previous values (unbind)

--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -77,6 +77,11 @@
       "title": "PHP upload max filesize",
       "description": "Maximum size of uploaded files"
     },
+    "php_memory_limit": {
+      "type": "string",
+      "title": "PHP memory limit",
+      "description": "Maximum amount of memory a script may consume"
+    },
     "phpmyadmin_enabled": {
       "type": "boolean",
       "title": "phpMyAdmin enabled",

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -32,6 +32,7 @@ config["mysql_user_pass"] = agent.read_envfile("password.env")["MYSQL_USER_PASS"
 
 config["create_mysql_user"] = os.getenv("CREATE_MYSQL_USER","False") == "True"
 config["php_upload_max_filesize"] = os.getenv("PHP_UPLOAD_MAX_FILESIZE","100").removesuffix('M')
+config['php_memory_limit'] = os.getenv("PHP_MEMORY_LIMIT","512").removesuffix('M')
 config["phpmyadmin_enabled"] = os.getenv("PHPMYADMIN_ENABLED","True") == "True"
 
 # Dump the configuration to stdout

--- a/imageroot/systemd/user/apache2-app.service
+++ b/imageroot/systemd/user/apache2-app.service
@@ -39,6 +39,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/apache2-app.pid \
     --env MYSQL_ADMIN_PASS=${MYSQL_ADMIN_PASS} \
     --env PHP_POST_MAX_SIZE=${PHP_UPLOAD_MAX_FILESIZE} \
     --env PHP_UPLOAD_MAX_FILESIZE=${PHP_UPLOAD_MAX_FILESIZE} \
+    --env PHP_MEMORY_LIMIT=${PHP_MEMORY_LIMIT} \
     --env PHPMYADMIN_ENABLED=${PHPMYADMIN_ENABLED} \
     ${LAMP_SERVER_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/apache2-app.ctr-id -t 10

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -65,7 +65,12 @@
     "mysql_user_db_placeholder": "Enter MySQL database name",
     "mysql_user_db_tooltip": "Name of the MySQL database to create",
     "mysql_user_db_helper": "This database cannot be changed from the UI once set, use phpMyAdmin",
-    "phpmyadmin_enabled": "Enable phpMyAdmin"
+    "phpmyadmin_enabled": "Enable phpMyAdmin",
+    "php_memory_limit": "PHP memory limit",
+    "php_memory_limit_helper": "This value is in MB",
+    "php_memory_limit_placeholder": "Enter PHP memory limit",
+    "php_memory_limit_tooltip": "Maximum amount of memory a script may consume"
+
   },
   "about": {
     "title": "About"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -190,6 +190,25 @@
                       $t("settings.php_upload_max_filesize_tooltip")
                     }}</template>
                   </NsTextInput>
+                  <NsTextInput
+                    :label="$t('settings.php_memory_limit')"
+                    v-model="php_memory_limit"
+                    type="number"
+                    :min="512"
+                    :placeholder="
+                      $t('settings.php_memory_limit_placeholder')
+                    "
+                    :disabled="
+                      loading.getConfiguration || loading.configureModule
+                    "
+                    :invalid-message="$t(error.php_memory_limit)"
+                    ref="php_memory_limit"
+                    :helper-text="$t('settings.php_memory_limit_helper')"
+                  >
+                    <template #tooltip>{{
+                      $t("settings.php_upload_max_filesize_tooltip")
+                    }}</template>
+                  </NsTextInput>
                 </template>
               </cv-accordion-item>
             </cv-accordion>
@@ -252,6 +271,7 @@ export default {
       phpmyadmin_enabled: true,
       create_mysql_user: false,
       php_upload_max_filesize: "100",
+      php_memory_limit: "512",
       mysql_user_name: "",
       mysql_user_db: "",
       mysql_user_pass: "",
@@ -272,6 +292,7 @@ export default {
         mysql_user_pass: "",
         mysql_admin_pass: "",
         php_upload_max_filesize: "",
+        php_memory_limit: "",
       },
     };
   },
@@ -347,6 +368,7 @@ export default {
       this.loading.getConfiguration = false;
       this.create_mysql_user = config.create_mysql_user;
       this.php_upload_max_filesize = config.php_upload_max_filesize;
+      this.php_memory_limit = config.php_memory_limit;
       this.phpmyadmin_enabled = config.phpmyadmin_enabled;
       this.focusElement("host");
     },
@@ -469,6 +491,7 @@ export default {
             mysql_admin_pass: this.mysql_admin_pass,
             create_mysql_user: this.create_mysql_user,
             php_upload_max_filesize: this.php_upload_max_filesize,
+            php_memory_limit: this.php_memory_limit,
             phpmyadmin_enabled: this.phpmyadmin_enabled,
           },
           extra: {

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -176,6 +176,8 @@
                     :label="$t('settings.php_upload_max_filesize')"
                     v-model="php_upload_max_filesize"
                     type="number"
+                    :min="100"
+                    :max="2048"
                     :placeholder="
                       $t('settings.php_upload_max_filesize_placeholder')
                     "
@@ -195,6 +197,7 @@
                     v-model="php_memory_limit"
                     type="number"
                     :min="512"
+                    :max="4096"
                     :placeholder="
                       $t('settings.php_memory_limit_placeholder')
                     "
@@ -206,7 +209,7 @@
                     :helper-text="$t('settings.php_memory_limit_helper')"
                   >
                     <template #tooltip>{{
-                      $t("settings.php_upload_max_filesize_tooltip")
+                      $t("settings.php_memory_limit_tooltip")
                     }}</template>
                   </NsTextInput>
                 </template>


### PR DESCRIPTION
Introduce a new configuration option for PHP memory limit, allowing users to set and retrieve this value through the environment, validation, and UI components.