### PR TITLE
Update @nethserver/ns8-ui-lib to v1.8.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@carbon/icons-vue": "^10.37.0",
     "@carbon/vue": "^2.40.0",
-    "@nethserver/ns8-ui-lib": "^1.6.0",
+    "@nethserver/ns8-ui-lib": "^1.8.0",
     "await-to-js": "^3.0.0",
     "axios": "^0.30.0",
     "carbon-components": "^10.41.0",
@@ -27,13 +27,13 @@
     "vuex": "^3.4.0"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.11.0",
     "@vue/cli-plugin-babel": "~4.5.0",
     "@vue/cli-plugin-eslint": "~4.5.0",
     "@vue/cli-plugin-router": "~4.5.0",
     "@vue/cli-plugin-vuex": "~4.5.0",
     "@vue/cli-service": "~4.5.0",
     "@vue/eslint-config-prettier": "^6.0.0",
-    "@babel/eslint-parser": "^7.11.0",
     "eslint": "^6.7.2",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-vue": "^6.2.2",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1034,9 +1034,9 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nethserver/ns8-ui-lib@^1.6.0":
+"@nethserver/ns8-ui-lib@^1.8.0":
   version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@nethserver/ns8-ui-lib/-/ns8-ui-lib-1.8.0.tgz#c2ee0042222b9f864a60fb6e2a1a6327631bfcdb"
+  resolved "https://registry.npmmirror.com/@nethserver/ns8-ui-lib/-/ns8-ui-lib-1.8.0.tgz#c2ee0042222b9f864a60fb6e2a1a6327631bfcdb"
   integrity sha512-8aZ4l6qDnZMfDSt3M0rAatbtXwrkTcRsTjydCjaMivefWDnzv2rUIgfCYsDPswtwmO/jvGBxs0sJRGgosBaM/w==
   dependencies:
     "@rollup/plugin-json" "^4.1.0"


### PR DESCRIPTION
Upgrade the @nethserver/ns8-ui-lib dependency to version 1.8.0 in both package.json and yarn.lock to ensure compatibility with the latest features and fixes.