### PR TITLE
Add script to set PHP max execution time in environment file

### DIFF
--- a/imageroot/update-module.d/21add_php_max_execution_time
+++ b/imageroot/update-module.d/21add_php_max_execution_time
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+set -e
+# Redirect any output to the journal (stderr)
+exec 1>&2
+
+# we set the PHP_MAX_EXECUTION_TIME variable in the environment file if not already set
+if [ -z "${PHP_MAX_EXECUTION_TIME}" ] || ! grep -q '^PHP_MAX_EXECUTION_TIME=' environment; then
+    PHP_MAX_EXECUTION_TIME="${PHP_MAX_EXECUTION_TIME:-600}"
+    echo "PHP_MAX_EXECUTION_TIME=$PHP_MAX_EXECUTION_TIME" >> environment
+else
+    # we have migrated clean old images with PHP_MAX_EXECUTION_TIME set
+    echo "PHP_MAX_EXECUTION_TIME is already set in environment file, skipping."
+fi


### PR DESCRIPTION
Introduce a script that sets the PHP max execution time in the environment file if it is not already defined. This ensures a default value is applied while avoiding overwriting existing configurations.