### PR TITLE
Update repository references to use nethserver namespace

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -11,7 +11,7 @@ set -e
 # Prepare variables for later use
 images=()
 # The image will be pushed to GitHub container registry
-repobase="${REPOBASE:-ghcr.io/stephdl}"
+repobase="${REPOBASE:-ghcr.io/nethserver}"
 # Configure the image name
 reponame="lamp"
 
@@ -59,7 +59,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
     --label="org.nethserver.min-core=3.12.4-0" \
-    --label="org.nethserver.images=ghcr.io/stephdl/lamp-server-php8.3:${IMAGETAG}" \
+    --label="org.nethserver.images=ghcr.io/nethserver/lamp-server-php8.3:${IMAGETAG}" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/container/index.php
+++ b/container/index.php
@@ -81,11 +81,11 @@ $osInfo = getOSInformation();
 <body>
     <div class="container">
         <header>
-            <h2>Welcome to <a href="https://github.com/stephdl/ns8-lamp" target="_blank">ns8-Lamp</a> a.k.a
+            <h2>Welcome to <a href="https://github.com/nethserver/ns8-lamp" target="_blank">ns8-Lamp</a> a.k.a
                 stephdl/ns8-lamp</h2>
         </header>
         <article>
-            <p>For documentation, <a href="https://github.com/stephdl/ns8-lamp" target="_blank">click here</a>.</p>
+            <p>For documentation, <a href="https://github.com/nethserver/ns8-lamp" target="_blank">click here</a>.</p>
             <p>For PHP information, <a href="phpinfo.php" target="_blank">click here</a>.</p>
 
             <div class="warning">

--- a/imageroot/bin/clean-images
+++ b/imageroot/bin/clean-images
@@ -12,7 +12,7 @@ exec 1>&2
 # We want to remove images that are not used by any containers.
 # We use `podman rmi` to remove images, ignoring errors if they are in use.
 
-for img_id in $(podman images --quiet --filter=reference='ghcr.io/stephdl/lamp-server*:*'); do
+for img_id in $(podman images --quiet --filter=reference='ghcr.io/nethserver/lamp-server*:*'); do
     # try to remove the image, print message if successful, ignore errors if it's in use
     if podman rmi "$img_id" 2>/dev/null; then
         echo "Removed image: $img_id"

--- a/imageroot/bin/download-php
+++ b/imageroot/bin/download-php
@@ -17,10 +17,10 @@ image_url="${IMAGE_URL:-? We expect IMAGE_URL environment variable}"
 # remove `ghcr.io/nethserver/webserver:`
 tag="${image_url##*:}"
 # save the php tag for later use in the systemd service
-echo "IMAGE_URL_TAG=ghcr.io/stephdl/lamp-server-php$minor_version:$tag" > image_url_tag.env
+echo "IMAGE_URL_TAG=ghcr.io/nethserver/lamp-server-php$minor_version:$tag" > image_url_tag.env
 # pull the image
-podman-pull-missing "ghcr.io/stephdl/lamp-server-php$minor_version:$tag"
+podman-pull-missing "ghcr.io/nethserver/lamp-server-php$minor_version:$tag"
 # Stop the timer
 end_time=$(date +%s)
 elapsed=$((end_time - start_time))
-echo "Downloaded ghcr.io/stephdl/lamp-server-php$minor_version:$tag in $elapsed seconds."
+echo "Downloaded ghcr.io/nethserver/lamp-server-php$minor_version:$tag in $elapsed seconds."

--- a/imageroot/update-module.d/80clean_former_image
+++ b/imageroot/update-module.d/80clean_former_image
@@ -10,7 +10,7 @@ exec 1>&2
 
 
 # for migration when we did not have PHP_VERSION set, we remove the old images with static PHP version
-for img_id in $(podman images --quiet --filter=reference='ghcr.io/stephdl/lamp-server:*'); do
+for img_id in $(podman images --quiet --filter=reference='ghcr.io/nethserver/lamp-server:*'); do
     # try to remove the image, print message if successful, ignore errors if it's in use
     if podman rmi "$img_id" 2>/dev/null; then
         echo "Removed image: $img_id"

--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -11,9 +11,9 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://github.com/stephdl/ns8-lamp",
-    "bug_url": "https://github.com/stephdl/dev",
-    "code_url": "https://github.com/stephdl/ns8-lamp"
+    "documentation_url": "https://github.com/nethserver/ns8-lamp",
+    "bug_url": "https://github.com/nethserver/dev",
+    "code_url": "https://github.com/nethserver/ns8-lamp"
   },
-  "source": "ghcr.io/stephdl/lamp"
+  "source": "ghcr.io/nethserver/lamp"
 }


### PR DESCRIPTION
Change all references from the stephdl namespace to the nethserver namespace across various files to ensure consistency and proper linkage to the new repository. This includes updates to image names, documentation links, and metadata.