### PR TITLE
Add migration script to remove old stephdl images for NethServer

### DIFF
--- a/imageroot/update-module.d/81clean_stephdl_image
+++ b/imageroot/update-module.d/81clean_stephdl_image
@@ -8,7 +8,7 @@ set -e
 # Redirect any output to the journal (stderr)
 exec 1>&2
 
-# Needed for the migration to NethServer, we have started with nethserver/lamp:1.2.4
+# Needed for the migration to the NethServer github repository, we have started with nethserver/lamp:1.2.4
 
 # for migration when we did not have PHP_VERSION set, we remove the old images with static PHP version
 for img_id in $(podman images --quiet --filter=reference='ghcr.io/stephdl/*'); do

--- a/imageroot/update-module.d/81clean_stephdl_image
+++ b/imageroot/update-module.d/81clean_stephdl_image
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+set -e
+# Redirect any output to the journal (stderr)
+exec 1>&2
+
+# Needed for the migration to NethServer, we have started with nethserver/lamp:1.2.4
+
+# for migration when we did not have PHP_VERSION set, we remove the old images with static PHP version
+for img_id in $(podman images --quiet --filter=reference='ghcr.io/stephdl/*'); do
+    # try to remove the image, print message if successful, ignore errors if it's in use
+    if podman rmi "$img_id" 2>/dev/null; then
+        echo "Removed image: $img_id"
+    fi
+done


### PR DESCRIPTION
Introduce a migration script that cleans up old stephdl images to facilitate the transition to NethServer. This script removes images with static PHP versions that are no longer needed.