### PR TITLE
Add support for custom scripts in the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ Syntax of a Cron Job:
 
 you can verify the cron by `podman exec -ti apache2-app crontab -l`
 
+## Custom scripts
+
+Custom scripts can be stored in the `./scripts` directory in the module state folder. These scripts are automatically mounted into the container at `/usr/local/sbin`, making them available as system commands that can be executed from anywhere within the container.
+
+This is useful for creating custom maintenance scripts, extending cron tasks with your own scripts, and adding helper commands for application management.
+
+Scripts placed in `./scripts` are included in the backup and will be restored when the module is recovered.
+
 ## Install
 
 Instantiate the module with:

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ you can verify the cron by `podman exec -ti apache2-app crontab -l`
 
 ## Custom scripts
 
-Custom scripts can be stored in the `./scripts` directory in the module state folder. These scripts are automatically mounted into the container at `/usr/local/sbin`, making them available as system commands that can be executed from anywhere within the container.
+Custom scripts can be stored in the `./scripts` directory in the module state folder. These scripts are automatically mounted into the container at `/opt/ns8-lamp/scripts`, making them available as system commands that can be executed from anywhere within the container.
 
 This is useful for creating custom maintenance scripts, extending cron tasks with your own scripts, and adding helper commands for application management.
 

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -26,6 +26,9 @@ ENV PHPMYADMIN_ENABLED True
 ARG PHP_VERSION
 ENV PHP_VERSION=$PHP_VERSION
 
+# Add custom scripts path
+ENV PATH=/opt/ns8-lamp/scripts:$PATH
+
 # Tweaks to give Apache/PHP write permissions to the app
 RUN usermod -u ${BOOT2DOCKER_ID} www-data && \
     usermod -G staff www-data && \
@@ -160,6 +163,7 @@ RUN echo "Editing APACHE_RUN_GROUP environment variable" && \
 RUN echo "Setting up MySQL directories" && \
         mkdir -p /var/run/mysqld && \
         mkdir -p /var/log/mysql && \
+        mkdir -p /opt/ns8-lamp/scripts && \
         chown -R mysql:mysql /var/run/mysqld && \
         chown -R mysql:mysql /var/log/mysql
 

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -11,3 +11,4 @@ state/password.env
 state/conf.d/mysql.cnf
 state/conf.d/mysqldump.cnf
 state/crontabs
+state/scripts

--- a/imageroot/systemd/user/apache2-app.service
+++ b/imageroot/systemd/user/apache2-app.service
@@ -21,7 +21,7 @@ TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/apache2-app.pid %t/apache2-app.ctr-id
 ExecStartPre=-runagent discover-smarthost
 ExecStartPre=-runagent discover-ldap
-ExecStartPre=/bin/mkdir -vp initdb.d crontabs
+ExecStartPre=/bin/mkdir -vp initdb.d crontabs scripts
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/apache2-app.pid \
     --cidfile %t/apache2-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/lamp.pod-id --replace -d --name  apache2-app \
@@ -31,6 +31,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/apache2-app.pid \
     --volume ./conf.d/mysql.cnf:/etc/mysql/conf.d/mysql.cnf:Z \
     --volume ./conf.d/mysqldump.cnf:/etc/mysql/conf.d/mysqldump.cnf:Z \
     --volume ./crontabs:/var/spool/cron/crontabs:Z \
+    --volume ./scripts:/usr/local/sbin:z \
     --env SMTP_* \
     --env LAMP_* \
     --env CREATE_MYSQL_USER=${CREATE_MYSQL_USER} \

--- a/imageroot/systemd/user/apache2-app.service
+++ b/imageroot/systemd/user/apache2-app.service
@@ -31,7 +31,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/apache2-app.pid \
     --volume ./conf.d/mysql.cnf:/etc/mysql/conf.d/mysql.cnf:Z \
     --volume ./conf.d/mysqldump.cnf:/etc/mysql/conf.d/mysqldump.cnf:Z \
     --volume ./crontabs:/var/spool/cron/crontabs:Z \
-    --volume ./scripts:/usr/local/sbin:z \
+    --volume ./scripts:/opt/ns8-lamp/scripts:Z \
     --env SMTP_* \
     --env LAMP_* \
     --env CREATE_MYSQL_USER=${CREATE_MYSQL_USER} \


### PR DESCRIPTION
Introduce a section in the README to document the use of custom scripts stored in the `./scripts` directory. Update the service file to create the `scripts` directory and ensure it is mounted into the container, allowing for easy execution of custom maintenance scripts and inclusion in backups. Additionally, modify the backup configuration to include the `scripts` directory.