### PR TITLE
Optimize build speed: shared base image + parallel PHP builds

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -21,8 +21,9 @@ PHP_VERSIONS=("7.4" "8.0" "8.1" "8.2" "8.3" "8.4" "8.5")
 PHPMYADMIN_VERSION="5.2.3"
 
 # Build the shared base image once (common packages, phpMyAdmin, Apache config...).
-# Uses a local-only name (no registry prefix) so it is never accidentally published.
-BASE_IMAGE="lamp-base-build"
+# Uses the localhost/ prefix so it is treated as a local image and never pulled
+# from or pushed to a remote registry.
+BASE_IMAGE="localhost/lamp-base-build"
 echo "Building shared base image..."
 podman build \
     --force-rm \
@@ -42,6 +43,7 @@ for PHP_VERSION in "${PHP_VERSIONS[@]}"; do
     podman build \
         --force-rm \
         --layers \
+        --pull-never \
         --tag "${repobase}/lamp-server-php${PHP_VERSION}" \
         --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
         --build-arg "PHP_VERSION=${PHP_VERSION}" \
@@ -117,10 +119,10 @@ images+=("${repobase}/${reponame}")
 #
 
 #
-# Setup CI when pushing to Github.
+# Setup CI when pushing to GitHub.
 # Warning! docker::// protocol expects lowercase letters (,,)
 if [[ -n "${CI}" ]]; then
-    # Set output value for Github Actions
+    # Set output value for GitHub Actions
     printf "images=%s\n" "${images[*],,}" >> "${GITHUB_OUTPUT}"
 else
     # Just print info for manual push

--- a/build-images.sh
+++ b/build-images.sh
@@ -20,8 +20,9 @@ reponame="lamp"
 PHP_VERSIONS=("7.4" "8.0" "8.1" "8.2" "8.3" "8.4" "8.5")
 PHPMYADMIN_VERSION="5.2.3"
 
-# Build the shared base image once (common packages, phpMyAdmin, Apache config...)
-BASE_IMAGE="${repobase}/lamp-base"
+# Build the shared base image once (common packages, phpMyAdmin, Apache config...).
+# Uses a local-only name (no registry prefix) so it is never accidentally published.
+BASE_IMAGE="lamp-base-build"
 echo "Building shared base image..."
 podman build \
     --force-rm \
@@ -64,8 +65,13 @@ done
 
 if [[ ${#failed[@]} -gt 0 ]]; then
     echo "ERROR: The following PHP version builds failed: ${failed[*]}" >&2
+    podman rmi "${BASE_IMAGE}" 2>/dev/null || true
     exit 1
 fi
+
+# Remove the base image: it is an intermediate build artifact, not meant to be published
+echo "Removing intermediate base image..."
+podman rmi "${BASE_IMAGE}" 2>/dev/null || true
 
 # Create a new empty container image
 container=$(buildah from scratch)

--- a/build-images.sh
+++ b/build-images.sh
@@ -20,19 +20,52 @@ reponame="lamp"
 PHP_VERSIONS=("7.4" "8.0" "8.1" "8.2" "8.3" "8.4" "8.5")
 PHPMYADMIN_VERSION="5.2.3"
 
-# Build images for each PHP version
+# Build the shared base image once (common packages, phpMyAdmin, Apache config...)
+BASE_IMAGE="${repobase}/lamp-base"
+echo "Building shared base image..."
+podman build \
+    --force-rm \
+    --layers \
+    --tag "${BASE_IMAGE}" \
+    --build-arg "PHPMYADMIN_VERSION=${PHPMYADMIN_VERSION}" \
+    --file container/Containerfile.base \
+    container
+
+# Build all PHP version images in parallel
+echo "Building PHP version images in parallel..."
+pids=()
+failed=()
+
 for PHP_VERSION in "${PHP_VERSIONS[@]}"; do
-    echo "Building lamp-server for PHP ${PHP_VERSION}..."
+    echo "  Starting build for PHP ${PHP_VERSION}..."
     podman build \
         --force-rm \
         --layers \
         --tag "${repobase}/lamp-server-php${PHP_VERSION}" \
+        --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
         --build-arg "PHP_VERSION=${PHP_VERSION}" \
-        --build-arg "PHPMYADMIN_VERSION=${PHPMYADMIN_VERSION}" \
-        container
-
-    images+=("${repobase}/lamp-server-php${PHP_VERSION}")
+        --file container/Containerfile \
+        container &
+    pids+=("$!:${PHP_VERSION}")
 done
+
+# Wait for all builds and collect failures
+for pid_ver in "${pids[@]}"; do
+    pid="${pid_ver%%:*}"
+    ver="${pid_ver##*:}"
+    if wait "${pid}"; then
+        echo "  PHP ${ver}: build OK"
+        images+=("${repobase}/lamp-server-php${ver}")
+    else
+        echo "  PHP ${ver}: build FAILED" >&2
+        failed+=("${ver}")
+    fi
+done
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+    echo "ERROR: The following PHP version builds failed: ${failed[*]}" >&2
+    exit 1
+fi
 
 # Create a new empty container image
 container=$(buildah from scratch)
@@ -78,7 +111,7 @@ images+=("${repobase}/${reponame}")
 #
 
 #
-# Setup CI when pushing to Github. 
+# Setup CI when pushing to Github.
 # Warning! docker::// protocol expects lowercase letters (,,)
 if [[ -n "${CI}" ]]; then
     # Set output value for Github Actions

--- a/build-images.sh
+++ b/build-images.sh
@@ -15,10 +15,28 @@ repobase="${REPOBASE:-ghcr.io/nethserver}"
 # Configure the image name
 reponame="lamp"
 
-
 # Define PHP versions to build
 PHP_VERSIONS=("7.4" "8.0" "8.1" "8.2" "8.3" "8.4" "8.5")
 PHPMYADMIN_VERSION="5.2.3"
+
+# Secure temp dir for FIFO (avoids TOCTOU race of mktemp -u)
+tmpdir=$(mktemp -d)
+result_fifo="${tmpdir}/result.fifo"
+mkfifo "${result_fifo}"
+# Open FIFO read-write to avoid blocking on open (no writer needed yet)
+exec 3<> "${result_fifo}"
+
+declare -a pids=()
+
+kill_all_builds() {
+    for pid in "${pids[@]}"; do
+        pkill -P "${pid}" 2>/dev/null || true  # kill podman and other children first
+        kill "${pid}" 2>/dev/null || true       # then kill the bash wrapper
+    done
+}
+trap 'kill_all_builds; exec 3<&-; exec 3>&-; rm -rf "${tmpdir}"' EXIT
+trap 'kill_all_builds; exit 130' INT
+trap 'kill_all_builds; exit 143' TERM
 
 # Build the shared base image once (common packages, phpMyAdmin, Apache config...).
 # Uses the localhost/ prefix so it is treated as a local image and never pulled
@@ -35,41 +53,41 @@ podman build \
 
 # Build all PHP version images in parallel
 echo "Building PHP version images in parallel..."
-pids=()
-failed=()
-
 for PHP_VERSION in "${PHP_VERSIONS[@]}"; do
     echo "  Starting build for PHP ${PHP_VERSION}..."
-    podman build \
-        --force-rm \
-        --layers \
-        --pull-never \
-        --tag "${repobase}/lamp-server-php${PHP_VERSION}" \
-        --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
-        --build-arg "PHP_VERSION=${PHP_VERSION}" \
-        --file container/Containerfile \
-        container &
-    pids+=("$!:${PHP_VERSION}")
+    (
+        result=0
+        # Reports result to FIFO on exit; handles normal exit and SIGTERM.
+        trap 'printf "%s %d\n" "${PHP_VERSION}" "${result}" >"${result_fifo}" 2>/dev/null || true' EXIT
+        set -o pipefail
+        podman build \
+            --force-rm \
+            --layers \
+            --pull-never \
+            --tag "${repobase}/lamp-server-php${PHP_VERSION}" \
+            --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
+            --build-arg "PHP_VERSION=${PHP_VERSION}" \
+            --file container/Containerfile \
+            container 2>&1 | sed -u "s/^/[PHP ${PHP_VERSION}] /" || result=$?
+    ) &
+    pids+=("$!")
 done
 
-# Wait for all builds and collect failures
-for pid_ver in "${pids[@]}"; do
-    pid="${pid_ver%%:*}"
-    ver="${pid_ver##*:}"
-    if wait "${pid}"; then
-        echo "  PHP ${ver}: build OK"
-        images+=("${repobase}/lamp-server-php${ver}")
-    else
-        echo "  PHP ${ver}: build FAILED" >&2
-        failed+=("${ver}")
+# Read results in completion order; stop everything on first failure
+total=${#PHP_VERSIONS[@]}
+for (( completed=0; completed<total; completed++ )); do
+    read -r done_version done_result <&3
+    if [[ "${done_result}" -ne 0 ]]; then
+        echo "[PHP ${done_version}] BUILD FAILED — killing remaining builds..." >&2
+        podman rmi "${BASE_IMAGE}" 2>/dev/null || true
+        exit 1
     fi
+    echo "[PHP ${done_version}] BUILD OK"
+    images+=("${repobase}/lamp-server-php${done_version}")
 done
 
-if [[ ${#failed[@]} -gt 0 ]]; then
-    echo "ERROR: The following PHP version builds failed: ${failed[*]}" >&2
-    podman rmi "${BASE_IMAGE}" 2>/dev/null || true
-    exit 1
-fi
+# Reap all background build jobs to avoid zombies
+wait "${pids[@]}"
 
 # Remove the base image: it is an intermediate build artifact, not meant to be published
 echo "Removing intermediate base image..."

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -69,6 +69,42 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&
     php -r "unlink('composer-setup.php');" && \
     mv composer.phar /usr/local/bin/composer
 
+# Verify PHP extensions — derived automatically from installed deb packages.
+# Three checks per extension:
+#   exit 20 — extension not loaded by php -m
+#   exit 30 — .so file missing on disk
+#   exit 40 — .so has unresolved runtime dependencies (ldd)
+RUN php_ver=$(php -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;') && \
+    ext_dir=$(php -r 'echo PHP_EXTENSION_DIR;') && \
+    skip="cli|common|dev|dbg|pdo-mysql" && \
+    loaded_exts=$(php -m 2>/dev/null | tr '[:upper:]' '[:lower:]') && \
+    dpkg -l "php${php_ver}-*" 2>/dev/null | awk '/^ii/{print $2}' | \
+    while IFS= read -r pkg; do \
+        ext="${pkg#php${php_ver}-}"; \
+        echo "${ext}" | grep -qE "^(${skip})$" && continue; \
+        if [ "${ext}" = "mysql" ]; then \
+            exts="mysqli pdo_mysql"; \
+        else \
+            exts="${ext}"; \
+        fi; \
+        for e in ${exts}; do \
+            if [ "${e}" = "opcache" ]; then \
+                echo "${loaded_exts}" | grep -qi "opcache" \
+                    || { echo "Missing PHP extension: ${e}"; exit 20; }; \
+            else \
+                echo "${loaded_exts}" | grep -qi "^${e}$" \
+                    || { echo "Missing PHP extension: ${e}"; exit 20; }; \
+            fi; \
+            ext_so="${ext_dir}/${e}.so"; \
+            [ -f "${ext_so}" ] \
+                || { echo "Missing .so for extension: ${e} (${ext_so})"; exit 30; }; \
+            if ldd "${ext_so}" 2>&1 | grep -q "not found"; then \
+                echo "Missing runtime dependency for ${e}.so"; exit 40; \
+            fi; \
+        done; \
+    done && \
+    echo "PHP ${php_ver}: all extensions verified OK (php -m, .so, ldd)"
+
 # Set working directory
 WORKDIR /app
 

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -62,8 +62,8 @@ RUN sed -ri \
 
 # Add composer - verify installer signature before executing (official procedure)
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-    EXPECTED_SIG="$(php -r "copy('https://composer.github.io/installer.sig', 'php://stdout');")" && \
-    ACTUAL_SIG="$(php -r "echo hash_file('sha384', 'composer-setup.php');")" && \
+    EXPECTED_SIG="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')" && \
+    ACTUAL_SIG="$(php -r 'echo hash_file("sha384", "composer-setup.php");')" && \
     if [ "$EXPECTED_SIG" != "$ACTUAL_SIG" ]; then echo 'ERROR: Composer installer signature mismatch' >&2; rm composer-setup.php; exit 1; fi && \
     php composer-setup.php && \
     php -r "unlink('composer-setup.php');" && \

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -60,8 +60,11 @@ RUN sed -ri \
         -e "s|^;error_log = syslog|error_log = /dev/stderr|" \
         /etc/php/${PHP_VERSION}/cli/php.ini
 
-# Add composer
+# Add composer - verify installer signature before executing (official procedure)
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+    EXPECTED_SIG="$(php -r "copy('https://composer.github.io/installer.sig', 'php://stdout');")" && \
+    ACTUAL_SIG="$(php -r "echo hash_file('sha384', 'composer-setup.php');")" && \
+    if [ "$EXPECTED_SIG" != "$ACTUAL_SIG" ]; then echo 'ERROR: Composer installer signature mismatch' >&2; rm composer-setup.php; exit 1; fi && \
     php composer-setup.php && \
     php -r "unlink('composer-setup.php');" && \
     mv composer.phar /usr/local/bin/composer

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -11,59 +11,60 @@ ENV PHP_MEMORY_LIMIT 512M
 ENV PHP_MAX_EXECUTION_TIME 600
 ENV PHPMYADMIN_ENABLED True
 
-# Install PHP version-specific packages
+# Install PHP version-specific packages, configure ini and clean up in a single layer
 RUN apt-get update && \
-  OPCACHE_PKG=$(if [ "${PHP_VERSION}" != "8.5" ]; then echo "php${PHP_VERSION}-opcache"; fi) && \
-  apt-get -y install \
-      libapache2-mod-php${PHP_VERSION} \
-      php${PHP_VERSION}-ftp \
-      php${PHP_VERSION}-ldap \
-      php${PHP_VERSION}-pdo-mysql \
-      php${PHP_VERSION}-mysql \
-      php${PHP_VERSION}-apcu \
-      php${PHP_VERSION}-gd \
-      php${PHP_VERSION}-xml \
-      php${PHP_VERSION}-mbstring \
-      php${PHP_VERSION}-memcached \
-      php${PHP_VERSION}-imagick \
-      php${PHP_VERSION}-intl \
-      php${PHP_VERSION}-bcmath \
-      php${PHP_VERSION}-bz2 \
-      php${PHP_VERSION}-gettext \
-      php${PHP_VERSION}-gmp \
-      php${PHP_VERSION}-imap \
-      php${PHP_VERSION}-odbc \
-      php${PHP_VERSION}-soap \
-      php${PHP_VERSION}-sqlite3 \
-      php${PHP_VERSION}-tidy \
-      php${PHP_VERSION}-zip \
-      php${PHP_VERSION}-curl \
-      php${PHP_VERSION}-cli \
-      php${PHP_VERSION}-common \
-      ${OPCACHE_PKG} \
-      php${PHP_VERSION}-readline && \
-  apt-get -y autoremove && \
-  apt-get -y clean
+    OPCACHE_PKG=$(if [ "${PHP_VERSION}" != "8.5" ]; then echo "php${PHP_VERSION}-opcache"; fi) && \
+    apt-get -y install --no-install-recommends \
+        libapache2-mod-php${PHP_VERSION} \
+        php${PHP_VERSION}-ftp \
+        php${PHP_VERSION}-ldap \
+        php${PHP_VERSION}-pdo-mysql \
+        php${PHP_VERSION}-mysql \
+        php${PHP_VERSION}-apcu \
+        php${PHP_VERSION}-gd \
+        php${PHP_VERSION}-xml \
+        php${PHP_VERSION}-mbstring \
+        php${PHP_VERSION}-memcached \
+        php${PHP_VERSION}-imagick \
+        php${PHP_VERSION}-intl \
+        php${PHP_VERSION}-bcmath \
+        php${PHP_VERSION}-bz2 \
+        php${PHP_VERSION}-gettext \
+        php${PHP_VERSION}-gmp \
+        php${PHP_VERSION}-imap \
+        php${PHP_VERSION}-odbc \
+        php${PHP_VERSION}-soap \
+        php${PHP_VERSION}-sqlite3 \
+        php${PHP_VERSION}-tidy \
+        php${PHP_VERSION}-zip \
+        php${PHP_VERSION}-curl \
+        php${PHP_VERSION}-cli \
+        php${PHP_VERSION}-common \
+        ${OPCACHE_PKG} \
+        php${PHP_VERSION}-readline && \
+    apt-get -y autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN echo "Updating settings for PHP ${PHP_VERSION}" && \
-        sed -ri -e "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}/" /etc/php/${PHP_VERSION}/apache2/php.ini \
-        -e "s/^post_max_size.*/post_max_size = ${PHP_POST_MAX_SIZE}/" /etc/php/${PHP_VERSION}/apache2/php.ini \
-        -e "s/^memory_limit.*/memory_limit = ${PHP_MEMORY_LIMIT}/" /etc/php/${PHP_VERSION}/apache2/php.ini \
-        -e "s/^max_execution_time.*/max_execution_time = ${PHP_MAX_EXECUTION_TIME}/" /etc/php/${PHP_VERSION}/apache2/php.ini \
-        -e "s/^;date.timezone.*/date.timezone = Europe\/London/" /etc/php/${PHP_VERSION}/apache2/php.ini \
-        -e "s|;sendmail_path =|sendmail_path = /usr/sbin/ssmtp -t|" /etc/php/${PHP_VERSION}/apache2/php.ini \
-        -e  "s/;date.timezone =/date.timezone = UTC/g" /etc/php/${PHP_VERSION}/cli/php.ini \
-        -e "s|^;error_log = syslog|error_log = /dev/stderr|" /etc/php/${PHP_VERSION}/apache2/php.ini \
-        -e "s|^;error_log = syslog|error_log = /dev/stderr|" /etc/php/${PHP_VERSION}/cli/php.ini
+RUN sed -ri \
+        -e "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}/" \
+        -e "s/^post_max_size.*/post_max_size = ${PHP_POST_MAX_SIZE}/" \
+        -e "s/^memory_limit.*/memory_limit = ${PHP_MEMORY_LIMIT}/" \
+        -e "s/^max_execution_time.*/max_execution_time = ${PHP_MAX_EXECUTION_TIME}/" \
+        -e "s/^;date.timezone.*/date.timezone = Europe\/London/" \
+        -e "s|;sendmail_path =|sendmail_path = /usr/sbin/ssmtp -t|" \
+        -e "s|^;error_log = syslog|error_log = /dev/stderr|" \
+        /etc/php/${PHP_VERSION}/apache2/php.ini && \
+    sed -ri \
+        -e "s/;date.timezone =/date.timezone = UTC/g" \
+        -e "s|^;error_log = syslog|error_log = /dev/stderr|" \
+        /etc/php/${PHP_VERSION}/cli/php.ini
 
 # Add composer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
     php composer-setup.php && \
     php -r "unlink('composer-setup.php');" && \
     mv composer.phar /usr/local/bin/composer
-
-# Final cleanup
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Set working directory
 WORKDIR /app

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -11,7 +11,7 @@ ENV PHP_MEMORY_LIMIT 512M
 ENV PHP_MAX_EXECUTION_TIME 600
 ENV PHPMYADMIN_ENABLED True
 
-# Install PHP version-specific packages, configure ini and clean up in a single layer
+# Install PHP version-specific packages and clean up in a single layer
 RUN apt-get update && \
     OPCACHE_PKG=$(if [ "${PHP_VERSION}" != "8.5" ]; then echo "php${PHP_VERSION}-opcache"; fi) && \
     apt-get -y install --no-install-recommends \

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,20 +1,8 @@
-FROM docker.io/ubuntu:noble-20260217
-MAINTAINER stephane de Labrusse <stephdl@de-labrusse.fr>
-ENV REFRESHED_AT 2024-08-25
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
-# based on Matthew Rayner <hello@rayner.io> https://github.com/mattrayner/docker-lamp
-# based on dgraziotin/lamp
-# MAINTAINER Daniel Graziotin <daniel@ineed.coffee>
-# updated for Ubuntu 20.04 LTS/PHP 7.4/PHP 8.0 Ferdinand Kasper <fkasper@modus-operandi.at>
-
-ENV DOCKER_USER_ID 501 
-ENV DOCKER_USER_GID 20
-
-ENV BOOT2DOCKER_ID 1005
-ENV BOOT2DOCKER_GID 50
-
-ARG PHPMYADMIN_VERSION
-ENV PHPMYADMIN_VERSION=$PHPMYADMIN_VERSION
+ARG PHP_VERSION
+ENV PHP_VERSION=$PHP_VERSION
 
 #Environment variables to configure php
 ENV PHP_UPLOAD_MAX_FILESIZE 100M
@@ -23,39 +11,11 @@ ENV PHP_MEMORY_LIMIT 512M
 ENV PHP_MAX_EXECUTION_TIME 600
 ENV PHPMYADMIN_ENABLED True
 
-ARG PHP_VERSION
-ENV PHP_VERSION=$PHP_VERSION
-
-# Tweaks to give Apache/PHP write permissions to the app
-RUN usermod -u ${BOOT2DOCKER_ID} www-data && \
-    usermod -G staff www-data && \
-    useradd -r mysql && \
-    usermod -G staff mysql && \
-    groupmod -g $(($BOOT2DOCKER_GID + 10000)) $(getent group $BOOT2DOCKER_GID | cut -d: -f1) && \
-    groupmod -g ${BOOT2DOCKER_GID} staff
-
-# Install packages
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt update && apt-get install -y software-properties-common python3-launchpadlib
-RUN LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php && \
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
-  apt-get update && \
-  apt-get -y upgrade && \
+# Install PHP version-specific packages
+RUN apt-get update && \
   OPCACHE_PKG=$(if [ "${PHP_VERSION}" != "8.5" ]; then echo "php${PHP_VERSION}-opcache"; fi) && \
-  apt-get -y install supervisor \
-      vim \
-      nano \
-      wget \
-      git \
-      tree \
-      cron \
-      apache2 \
+  apt-get -y install \
       libapache2-mod-php${PHP_VERSION} \
-      mariadb-server \
-      pwgen \
-      ftp \
-      ftp-ssl \
-      ssmtp \
       php${PHP_VERSION}-ftp \
       php${PHP_VERSION}-ldap \
       php${PHP_VERSION}-pdo-mysql \
@@ -81,34 +41,9 @@ RUN LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php && \
       php${PHP_VERSION}-cli \
       php${PHP_VERSION}-common \
       ${OPCACHE_PKG} \
-      php${PHP_VERSION}-readline \
-      zip \
-      unzip \
-      curl && \
+      php${PHP_VERSION}-readline && \
   apt-get -y autoremove && \
-  apt-get -y clean && \
-  echo "ServerName localhost" >> /etc/apache2/apache2.conf
-
-# Add image configuration and scripts
-ADD start-apache2.sh /start-apache2.sh
-ADD run.sh /run.sh
-RUN chmod 755 /*.sh
-ADD supervisord-apache2.conf /etc/supervisor/conf.d/supervisord-apache2.conf
-ADD supervisord-mysqld.conf /etc/supervisor/conf.d/supervisord-mysqld.conf
-ADD supervisord-cron.conf /etc/supervisor/conf.d/supervisord-cron.conf
-ADD supervisord.conf /etc/supervisor/supervisord.conf
-
-# Remove pre-installed database
-RUN rm -rf /var/lib/mysql
-
-# Add MySQL utils
-ADD mysql_init.sh /mysql_init.sh
-
-# Add phpmyadmin
-RUN wget -O /tmp/phpmyadmin.tar.gz https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz
-RUN tar xfvz /tmp/phpmyadmin.tar.gz -C /var/www
-RUN ln -s /var/www/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages /var/www/phpmyadmin
-RUN mv /var/www/phpmyadmin/config.sample.inc.php /var/www/phpmyadmin/config.inc.php
+  apt-get -y clean
 
 RUN echo "Updating settings for PHP ${PHP_VERSION}" && \
         sed -ri -e "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE}/" /etc/php/${PHP_VERSION}/apache2/php.ini \
@@ -127,43 +62,7 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&
     php -r "unlink('composer-setup.php');" && \
     mv composer.phar /usr/local/bin/composer
 
-# config to enable .htaccess
-ADD apache_default /etc/apache2/sites-available/000-default.conf
-RUN a2enmod rewrite proxy_http headers expires
-
-# enable real IP logging
-RUN a2enmod remoteip && echo "RemoteIPHeader X-Forwarded-For" > /etc/apache2/conf-available/remoteip.conf && \
-    echo "RemoteIPInternalProxy 10.0.0.0/8" >> /etc/apache2/conf-available/remoteip.conf && \
-    a2enconf remoteip
-
-RUN echo "# log apache to stderr" && \
-        ln -sf /dev/stderr /var/log/apache2/access.log && \
-        ln -sf /dev/stderr /var/log/apache2/error.log
-
-
- RUN echo "# Listen only on IPv4 addresses" && \
-    sed -i 's/^Listen .*/Listen 0.0.0.0:80/' /etc/apache2/ports.conf
-
-
-# Configure /app folder with sample app
-RUN mkdir -p /app && rm -fr /var/www/html && ln -s /app /var/www/html
-ADD index.php /app
-ADD phpinfo.php /app
-
-RUN echo "Allowing Apache/PHP to write to the app" && \
-        chown -R www-data:staff /var/www && \
-        chown -R www-data:staff /app
-
-RUN echo "Editing APACHE_RUN_GROUP environment variable" && \
-        sed -i "s/export APACHE_RUN_GROUP=www-data/export APACHE_RUN_GROUP=staff/" /etc/apache2/envvars
-
-RUN echo "Setting up MySQL directories" && \
-        mkdir -p /var/run/mysqld && \
-        mkdir -p /var/log/mysql && \
-        chown -R mysql:mysql /var/run/mysqld && \
-        chown -R mysql:mysql /var/log/mysql
-
-# clean up
+# Final cleanup
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Set working directory

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,3 +1,5 @@
+# BASE_IMAGE must point to the locally built base image (built by build-images.sh).
+# Example: --build-arg BASE_IMAGE=localhost/ns8-lamp-base:latest
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 

--- a/container/Containerfile.base
+++ b/container/Containerfile.base
@@ -72,10 +72,12 @@ ADD mysql_init.sh /mysql_init.sh
 
 # Add phpmyadmin: download, extract, configure and remove archive in a single layer
 RUN wget -O /tmp/phpmyadmin.tar.gz https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz && \
+    wget -O /tmp/phpmyadmin.tar.gz.sha256 https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz.sha256 && \
+    (cd /tmp && sha256sum --check phpmyadmin.tar.gz.sha256) && \
     tar xfz /tmp/phpmyadmin.tar.gz -C /var/www && \
     ln -s /var/www/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages /var/www/phpmyadmin && \
     mv /var/www/phpmyadmin/config.sample.inc.php /var/www/phpmyadmin/config.inc.php && \
-    rm /tmp/phpmyadmin.tar.gz
+    rm /tmp/phpmyadmin.tar.gz /tmp/phpmyadmin.tar.gz.sha256
 
 # config to enable .htaccess
 ADD apache_default /etc/apache2/sites-available/000-default.conf

--- a/container/Containerfile.base
+++ b/container/Containerfile.base
@@ -1,0 +1,104 @@
+FROM docker.io/ubuntu:noble-20260217
+MAINTAINER stephane de Labrusse <stephdl@de-labrusse.fr>
+ENV REFRESHED_AT 2024-08-25
+
+# based on Matthew Rayner <hello@rayner.io> https://github.com/mattrayner/docker-lamp
+# based on dgraziotin/lamp
+# MAINTAINER Daniel Graziotin <daniel@ineed.coffee>
+# updated for Ubuntu 20.04 LTS/PHP 7.4/PHP 8.0 Ferdinand Kasper <fkasper@modus-operandi.at>
+
+ENV DOCKER_USER_ID 501
+ENV DOCKER_USER_GID 20
+
+ENV BOOT2DOCKER_ID 1005
+ENV BOOT2DOCKER_GID 50
+
+ARG PHPMYADMIN_VERSION
+ENV PHPMYADMIN_VERSION=$PHPMYADMIN_VERSION
+
+# Tweaks to give Apache/PHP write permissions to the app
+RUN usermod -u ${BOOT2DOCKER_ID} www-data && \
+    usermod -G staff www-data && \
+    useradd -r mysql && \
+    usermod -G staff mysql && \
+    groupmod -g $(($BOOT2DOCKER_GID + 10000)) $(getent group $BOOT2DOCKER_GID | cut -d: -f1) && \
+    groupmod -g ${BOOT2DOCKER_GID} staff
+
+# Install common packages and add PHP PPA (without PHP itself)
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt update && apt-get install -y software-properties-common python3-launchpadlib
+RUN LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php && \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
+  apt-get update && \
+  apt-get -y upgrade && \
+  apt-get -y install \
+      supervisor \
+      vim \
+      nano \
+      wget \
+      git \
+      tree \
+      cron \
+      apache2 \
+      mariadb-server \
+      pwgen \
+      ftp \
+      ftp-ssl \
+      ssmtp \
+      zip \
+      unzip \
+      curl && \
+  apt-get -y autoremove && \
+  echo "ServerName localhost" >> /etc/apache2/apache2.conf
+
+# Add image configuration and scripts
+ADD start-apache2.sh /start-apache2.sh
+ADD run.sh /run.sh
+RUN chmod 755 /*.sh
+ADD supervisord-apache2.conf /etc/supervisor/conf.d/supervisord-apache2.conf
+ADD supervisord-mysqld.conf /etc/supervisor/conf.d/supervisord-mysqld.conf
+ADD supervisord-cron.conf /etc/supervisor/conf.d/supervisord-cron.conf
+ADD supervisord.conf /etc/supervisor/supervisord.conf
+
+# Remove pre-installed database
+RUN rm -rf /var/lib/mysql
+
+# Add MySQL utils
+ADD mysql_init.sh /mysql_init.sh
+
+# Add phpmyadmin
+RUN wget -O /tmp/phpmyadmin.tar.gz https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz
+RUN tar xfvz /tmp/phpmyadmin.tar.gz -C /var/www
+RUN ln -s /var/www/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages /var/www/phpmyadmin
+RUN mv /var/www/phpmyadmin/config.sample.inc.php /var/www/phpmyadmin/config.inc.php
+
+# config to enable .htaccess
+ADD apache_default /etc/apache2/sites-available/000-default.conf
+RUN a2enmod rewrite proxy_http headers expires
+
+# enable real IP logging
+RUN a2enmod remoteip && echo "RemoteIPHeader X-Forwarded-For" > /etc/apache2/conf-available/remoteip.conf && \
+    echo "RemoteIPInternalProxy 10.0.0.0/8" >> /etc/apache2/conf-available/remoteip.conf && \
+    a2enconf remoteip
+
+RUN ln -sf /dev/stderr /var/log/apache2/access.log && \
+    ln -sf /dev/stderr /var/log/apache2/error.log
+
+RUN sed -i 's/^Listen .*/Listen 0.0.0.0:80/' /etc/apache2/ports.conf
+
+# Configure /app folder with sample app
+RUN mkdir -p /app && rm -fr /var/www/html && ln -s /app /var/www/html
+ADD index.php /app
+ADD phpinfo.php /app
+
+RUN chown -R www-data:staff /var/www && \
+    chown -R www-data:staff /app
+
+RUN sed -i "s/export APACHE_RUN_GROUP=www-data/export APACHE_RUN_GROUP=staff/" /etc/apache2/envvars
+
+RUN mkdir -p /var/run/mysqld && \
+    mkdir -p /var/log/mysql && \
+    chown -R mysql:mysql /var/run/mysqld && \
+    chown -R mysql:mysql /var/log/mysql
+
+# Keep apt lists available for child image PHP installation

--- a/container/Containerfile.base
+++ b/container/Containerfile.base
@@ -1,5 +1,5 @@
 FROM docker.io/ubuntu:noble-20260217
-MAINTAINER stephane de Labrusse <stephdl@de-labrusse.fr>
+LABEL org.opencontainers.image.authors="stephane de Labrusse <stephdl@de-labrusse.fr>"
 ENV REFRESHED_AT 2024-08-25
 
 # based on Matthew Rayner <hello@rayner.io> https://github.com/mattrayner/docker-lamp
@@ -32,7 +32,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common python3-launchpadlib && \
     LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php && \
     apt-get update && \
-    apt-get -y upgrade && \
     apt-get -y install --no-install-recommends \
         supervisor \
         vim \

--- a/container/Containerfile.base
+++ b/container/Containerfile.base
@@ -31,7 +31,6 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common python3-launchpadlib && \
     LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
     apt-get update && \
     apt-get -y upgrade && \
     apt-get -y install --no-install-recommends \

--- a/container/Containerfile.base
+++ b/container/Containerfile.base
@@ -39,6 +39,7 @@ RUN apt-get update && \
         nano \
         wget \
         git \
+        tree \
         cron \
         apache2 \
         mariadb-server \

--- a/container/Containerfile.base
+++ b/container/Containerfile.base
@@ -24,32 +24,37 @@ RUN usermod -u ${BOOT2DOCKER_ID} www-data && \
     groupmod -g $(($BOOT2DOCKER_GID + 10000)) $(getent group $BOOT2DOCKER_GID | cut -d: -f1) && \
     groupmod -g ${BOOT2DOCKER_GID} staff
 
-# Install common packages and add PHP PPA (without PHP itself)
+# Add PHP PPA and install common packages.
+# software-properties-common and python3-launchpadlib are only needed to add the PPA
+# and are purged in the same layer to avoid bloating the image.
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt update && apt-get install -y software-properties-common python3-launchpadlib
-RUN LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php && \
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
-  apt-get update && \
-  apt-get -y upgrade && \
-  apt-get -y install \
-      supervisor \
-      vim \
-      nano \
-      wget \
-      git \
-      tree \
-      cron \
-      apache2 \
-      mariadb-server \
-      pwgen \
-      ftp \
-      ftp-ssl \
-      ssmtp \
-      zip \
-      unzip \
-      curl && \
-  apt-get -y autoremove && \
-  echo "ServerName localhost" >> /etc/apache2/apache2.conf
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common python3-launchpadlib && \
+    LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C && \
+    apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install --no-install-recommends \
+        supervisor \
+        vim \
+        nano \
+        wget \
+        git \
+        cron \
+        apache2 \
+        mariadb-server \
+        pwgen \
+        ftp \
+        ftp-ssl \
+        ssmtp \
+        zip \
+        unzip \
+        curl && \
+    apt-get -y purge --auto-remove software-properties-common python3-launchpadlib && \
+    apt-get -y autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
 # Add image configuration and scripts
 ADD start-apache2.sh /start-apache2.sh
@@ -66,25 +71,23 @@ RUN rm -rf /var/lib/mysql
 # Add MySQL utils
 ADD mysql_init.sh /mysql_init.sh
 
-# Add phpmyadmin
-RUN wget -O /tmp/phpmyadmin.tar.gz https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz
-RUN tar xfvz /tmp/phpmyadmin.tar.gz -C /var/www
-RUN ln -s /var/www/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages /var/www/phpmyadmin
-RUN mv /var/www/phpmyadmin/config.sample.inc.php /var/www/phpmyadmin/config.inc.php
+# Add phpmyadmin: download, extract, configure and remove archive in a single layer
+RUN wget -O /tmp/phpmyadmin.tar.gz https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz && \
+    tar xfz /tmp/phpmyadmin.tar.gz -C /var/www && \
+    ln -s /var/www/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages /var/www/phpmyadmin && \
+    mv /var/www/phpmyadmin/config.sample.inc.php /var/www/phpmyadmin/config.inc.php && \
+    rm /tmp/phpmyadmin.tar.gz
 
 # config to enable .htaccess
 ADD apache_default /etc/apache2/sites-available/000-default.conf
-RUN a2enmod rewrite proxy_http headers expires
-
-# enable real IP logging
-RUN a2enmod remoteip && echo "RemoteIPHeader X-Forwarded-For" > /etc/apache2/conf-available/remoteip.conf && \
+RUN a2enmod rewrite proxy_http headers expires && \
+    a2enmod remoteip && \
+    echo "RemoteIPHeader X-Forwarded-For" > /etc/apache2/conf-available/remoteip.conf && \
     echo "RemoteIPInternalProxy 10.0.0.0/8" >> /etc/apache2/conf-available/remoteip.conf && \
-    a2enconf remoteip
-
-RUN ln -sf /dev/stderr /var/log/apache2/access.log && \
-    ln -sf /dev/stderr /var/log/apache2/error.log
-
-RUN sed -i 's/^Listen .*/Listen 0.0.0.0:80/' /etc/apache2/ports.conf
+    a2enconf remoteip && \
+    ln -sf /dev/stderr /var/log/apache2/access.log && \
+    ln -sf /dev/stderr /var/log/apache2/error.log && \
+    sed -i 's/^Listen .*/Listen 0.0.0.0:80/' /etc/apache2/ports.conf
 
 # Configure /app folder with sample app
 RUN mkdir -p /app && rm -fr /var/www/html && ln -s /app /var/www/html
@@ -92,13 +95,9 @@ ADD index.php /app
 ADD phpinfo.php /app
 
 RUN chown -R www-data:staff /var/www && \
-    chown -R www-data:staff /app
-
-RUN sed -i "s/export APACHE_RUN_GROUP=www-data/export APACHE_RUN_GROUP=staff/" /etc/apache2/envvars
-
-RUN mkdir -p /var/run/mysqld && \
+    chown -R www-data:staff /app && \
+    sed -i "s/export APACHE_RUN_GROUP=www-data/export APACHE_RUN_GROUP=staff/" /etc/apache2/envvars && \
+    mkdir -p /var/run/mysqld && \
     mkdir -p /var/log/mysql && \
     chown -R mysql:mysql /var/run/mysqld && \
     chown -R mysql:mysql /var/log/mysql
-
-# Keep apt lists available for child image PHP installation

--- a/container/Containerfile.base
+++ b/container/Containerfile.base
@@ -1,6 +1,6 @@
 FROM docker.io/ubuntu:noble-20260217
 LABEL org.opencontainers.image.authors="stephane de Labrusse <stephdl@de-labrusse.fr>"
-ENV REFRESHED_AT 2024-08-25
+ENV REFRESHED_AT 2026-02-17
 
 # based on Matthew Rayner <hello@rayner.io> https://github.com/mattrayner/docker-lamp
 # based on dgraziotin/lamp
@@ -15,6 +15,9 @@ ENV BOOT2DOCKER_GID 50
 
 ARG PHPMYADMIN_VERSION
 ENV PHPMYADMIN_VERSION=$PHPMYADMIN_VERSION
+# Fail early with a clear message if PHPMYADMIN_VERSION was not provided.
+RUN test -n "$PHPMYADMIN_VERSION" || \
+    { echo "ERROR: PHPMYADMIN_VERSION build-arg is required. Pass --build-arg PHPMYADMIN_VERSION=<version>." >&2; exit 1; }
 
 # Tweaks to give Apache/PHP write permissions to the app
 RUN usermod -u ${BOOT2DOCKER_ID} www-data && \

--- a/container/Containerfile.base
+++ b/container/Containerfile.base
@@ -71,13 +71,13 @@ RUN rm -rf /var/lib/mysql
 ADD mysql_init.sh /mysql_init.sh
 
 # Add phpmyadmin: download, extract, configure and remove archive in a single layer
-RUN wget -O /tmp/phpmyadmin.tar.gz https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz && \
-    wget -O /tmp/phpmyadmin.tar.gz.sha256 https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz.sha256 && \
-    (cd /tmp && sha256sum --check phpmyadmin.tar.gz.sha256) && \
-    tar xfz /tmp/phpmyadmin.tar.gz -C /var/www && \
+RUN wget -P /tmp https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz && \
+    wget -P /tmp https://files.phpmyadmin.net/phpMyAdmin/${PHPMYADMIN_VERSION}/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz.sha256 && \
+    (cd /tmp && sha256sum --check phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz.sha256) && \
+    tar xfz /tmp/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz -C /var/www && \
     ln -s /var/www/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages /var/www/phpmyadmin && \
     mv /var/www/phpmyadmin/config.sample.inc.php /var/www/phpmyadmin/config.inc.php && \
-    rm /tmp/phpmyadmin.tar.gz /tmp/phpmyadmin.tar.gz.sha256
+    rm /tmp/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz /tmp/phpMyAdmin-${PHPMYADMIN_VERSION}-all-languages.tar.gz.sha256
 
 # config to enable .htaccess
 ADD apache_default /etc/apache2/sites-available/000-default.conf

--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,5 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "local>NethServer/.github:ns8"
-    ],
-    "dockerfile": {
-        "fileMatch": ["(^|/)Containerfile(\\.\\w+)?$", "(^|/)Dockerfile$"]
-    }
+    ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "local>NethServer/.github:ns8"
-    ]
+    ],
+    "dockerfile": {
+        "fileMatch": ["(^|/)Containerfile(\\.\\w+)?$", "(^|/)Dockerfile$"]
+    }
 }


### PR DESCRIPTION
## Summary

- Split `Containerfile` into a shared `Containerfile.base` (common packages: apache2, mariadb, phpMyAdmin, scripts, Apache config) and a PHP-specific `Containerfile` that inherits from it via `ARG BASE_IMAGE`
- The base image is built **once** instead of 7 times, eliminating redundant apt installs and phpMyAdmin downloads
- All 7 PHP version images are now built **in parallel** in `build-images.sh`, with proper error collection and reporting

## Expected improvement

| Before | After |
|--------|-------|
| 7 × sequential full builds (~35–70 min) | 1 base build + 7 parallel PHP builds (~8–15 min) |

