### PR TITLE
Add Apache document root configuration

### DIFF
--- a/container/apache_default
+++ b/container/apache_default
@@ -9,7 +9,7 @@
         Require all granted
     </Directory>
 
-    <Directory "/var/www/html">
+    <Directory /var/www/html>
         AllowOverride All
         Require all granted
     </Directory>

--- a/container/run.sh
+++ b/container/run.sh
@@ -54,6 +54,17 @@ echo "Updating settings for PHP CLI ${PHP_VERSION}" && \
 echo "Editing phpmyadmin config" && \
     sed -i "s/cfg\['blowfish_secret'\] = ''/cfg['blowfish_secret'] = '`openssl rand -hex 16`'/" /var/www/phpmyadmin/config.inc.php
 
+# Update DocumentRoot if APACHE_DOCUMENT_ROOT is provided
+if [[ -n "$APACHE_DOCUMENT_ROOT" ]]; then
+    # Strip any leading slash to avoid double slashes in the path
+    APACHE_DOCUMENT_ROOT="${APACHE_DOCUMENT_ROOT#/}"
+    echo "Setting DocumentRoot to /var/www/html/${APACHE_DOCUMENT_ROOT}"
+    sed -i \
+        -e "s|DocumentRoot /var/www/html|DocumentRoot /var/www/html/${APACHE_DOCUMENT_ROOT}|" \
+        -e "s|<Directory /var/www/html>|<Directory /var/www/html/${APACHE_DOCUMENT_ROOT}>|" \
+        /etc/apache2/sites-available/000-default.conf
+fi
+
 # Check if phpMyAdmin is enabled
 if [[ "$PHPMYADMIN_ENABLED" == "False" ]]; then
     echo "Disabling phpMyAdmin"

--- a/imageroot/actions/configure-module/20configure_environment_vars
+++ b/imageroot/actions/configure-module/20configure_environment_vars
@@ -32,5 +32,7 @@ agent.bind_user_domains([os.environ.get('LAMP_LDAP_DOMAIN','')])
 
 agent.set_env("PHP_VERSION", data.get("php_version",'8.3'))
 
+agent.set_env("APACHE_DOCUMENT_ROOT", data.get("apache_document_root", ''))
+
 agent.set_env("TRAEFIK_HOST", data["host"])
 agent.set_env("TRAEFIK_HTTP2HTTPS", data.get("http2https", True))

--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -17,7 +17,8 @@
       "phpmyadmin_enabled": true,
       "php_version": "8.3",
       "php_max_execution_time": "600",
-      "php_memory_limit": "512M"
+      "php_memory_limit": "512M",
+      "apache_document_root": "htdocs"
     }
   ],
   "type": "object",
@@ -100,6 +101,11 @@
       "type": "string",
       "title": "PHP max execution time",
       "description": "Maximum execution time of each script, in seconds"
+    },
+    "apache_document_root": {
+      "type": "string",
+      "title": "Apache document root subdirectory",
+      "description": "Subdirectory under /var/www/html to use as DocumentRoot (e.g. htdocs)"
     }
   }
 }

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -36,5 +36,6 @@ config['php_memory_limit'] = os.getenv("PHP_MEMORY_LIMIT","512").removesuffix('M
 config['php_max_execution_time'] = os.getenv("PHP_MAX_EXECUTION_TIME","600")
 config["phpmyadmin_enabled"] = os.getenv("PHPMYADMIN_ENABLED","True") == "True"
 config["php_version"] = os.getenv("PHP_VERSION","8.3")
+config["apache_document_root"] = os.getenv("APACHE_DOCUMENT_ROOT","")
 # Dump the configuration to stdout
 json.dump(config, fp=sys.stdout)

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -86,6 +86,11 @@
       "type": "string",
       "title": "PHP Version",
       "description": "Version of PHP to use"
+    },
+    "apache_document_root": {
+      "type": "string",
+      "title": "Apache document root subdirectory",
+      "description": "Subdirectory under /var/www/html to use as DocumentRoot (e.g. htdocs)"
     }
   }
 }

--- a/imageroot/systemd/user/apache2-app.service
+++ b/imageroot/systemd/user/apache2-app.service
@@ -43,6 +43,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/apache2-app.pid \
     --env PHP_MEMORY_LIMIT=${PHP_MEMORY_LIMIT} \
     --env PHP_MAX_EXECUTION_TIME=${PHP_MAX_EXECUTION_TIME} \
     --env PHPMYADMIN_ENABLED=${PHPMYADMIN_ENABLED} \
+    --env APACHE_DOCUMENT_ROOT=${APACHE_DOCUMENT_ROOT} \
     ${IMAGE_URL_TAG}
 ExecStartPost=runagent wait-after-apache
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/apache2-app.ctr-id -t 10

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -70,7 +70,11 @@
         "php_max_execution_time_helper": "Enter 0 to set no time limit, otherwise enter the maximum execution time in seconds",
         "megabytes": "MB",
         "second": "second | seconds",
-        "unlimited": "Unlimited"
+        "unlimited": "Unlimited",
+        "apache_document_root": "Apache document root subdirectory",
+        "apache_document_root_placeholder": "e.g. public",
+        "apache_document_root_helper": "Subdirectory under /var/www/html used as DocumentRoot. Leave empty to use /var/www/html directly.",
+        "apache_document_root_tooltip": "Set this if your application serves files from a subdirectory. Leave empty if not needed."
     },
     "about": {
         "title": "About"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -313,6 +313,20 @@
                         : $tc('settings.second', parseInt(MaxExecutionTime))
                     "
                   />
+                  <NsTextInput
+                    :label="$t('settings.apache_document_root')"
+                    v-model.trim="apache_document_root"
+                    :placeholder="$t('settings.apache_document_root_placeholder')"
+                    :helper-text="$t('settings.apache_document_root_helper')"
+                    :invalid-message="$t(error.apache_document_root)"
+                    :disabled="stillLoading"
+                    ref="apache_document_root"
+                    class="mg-bottom"
+                  >
+                    <template #tooltip>{{
+                      $t('settings.apache_document_root_tooltip')
+                    }}</template>
+                  </NsTextInput>
                 </template>
               </cv-accordion-item>
             </cv-accordion>
@@ -408,6 +422,7 @@ export default {
       mysql_admin_pass: "",
       firstConfig: true,
       PhpVersion: "8.3",
+      apache_document_root: "",
       loading: {
         getConfiguration: false,
         configureModule: false,
@@ -428,6 +443,7 @@ export default {
         php_memory_limit: "",
         getStatus: false,
         MaxExecutionTime: "",
+        apache_document_root: "",
       },
     };
   },
@@ -573,6 +589,7 @@ export default {
       this.phpmyadmin_enabled = config.phpmyadmin_enabled;
       this.PhpVersion = config.php_version;
       this.MaxExecutionTime = config.php_max_execution_time.toString();
+      this.apache_document_root = config.apache_document_root || "";
       this.focusElement("host");
     },
     validateConfigureModule() {
@@ -703,6 +720,7 @@ export default {
             phpmyadmin_enabled: this.phpmyadmin_enabled,
             php_version: this.PhpVersion,
             php_max_execution_time: this.MaxExecutionTime.toString(),
+            apache_document_root: this.apache_document_root,
           },
           extra: {
             title: this.$t("settings.instance_configuration", {


### PR DESCRIPTION
Enhance the Apache configuration by introducing a document root setting, allowing users to specify a subdirectory under `/var/www/html`. This update includes input validation, environment variable support, and UI adjustments for better user experience.